### PR TITLE
feat: 공용 컴포넌트 Container 작업

### DIFF
--- a/components/common/layout/Container.tsx
+++ b/components/common/layout/Container.tsx
@@ -1,0 +1,18 @@
+import { cn } from '@/utils/cn';
+import type { ReactNode } from 'react';
+
+interface ContainerProps {
+  children: ReactNode;
+  className?: string;
+  as?: React.ElementType; // 선택: div | section | main 등
+}
+
+export default function Container({ children, className, as: Component = 'div' }: ContainerProps) {
+  return (
+    <Component
+      className={cn('w-full mx-auto max-w-300 box-border', 'px-4 lg:px-0 sm:px-6', className)}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/components/common/layout/Container.tsx
+++ b/components/common/layout/Container.tsx
@@ -4,15 +4,12 @@ import type { ReactNode } from 'react';
 interface ContainerProps {
   children: ReactNode;
   className?: string;
-  as?: React.ElementType; // 선택: div | section | main 등
 }
 
-export default function Container({ children, className, as: Component = 'div' }: ContainerProps) {
+export default function Container({ children, className }: ContainerProps) {
   return (
-    <Component
-      className={cn('w-full mx-auto max-w-300 box-border', 'px-4 lg:px-0 sm:px-6', className)}
-    >
+    <div className={cn('w-full mx-auto max-w-300 box-border', 'px-4 lg:px-0 sm:px-6', className)}>
       {children}
-    </Component>
+    </div>
   );
 }

--- a/components/common/layout/Container.tsx
+++ b/components/common/layout/Container.tsx
@@ -8,7 +8,7 @@ interface ContainerProps {
 
 export default function Container({ children, className }: ContainerProps) {
   return (
-    <div className={cn('w-full mx-auto max-w-300 box-border', 'px-4 lg:px-0 sm:px-6', className)}>
+<div className={cn('w-full mx-auto max-w-300 box-border', 'px-4 sm:px-6 lg:px-0', className)}>
       {children}
     </div>
   );


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- 페이지 전반에서 반복되는 콘텐츠 영역 레이아웃 규칙(폭 제한 + 중앙 정렬 + 반응형)을 공통화하기 위해 Container 컴포넌트를 작업했습니다.
- 페이지마다 외부 container에 style을 적용하다보면 페이지별로 상이한 부분이 나오게 될 수도 있을 것 같아 작업하게 되었습니다.
- 사용하는 곳에서 style overriding을 통해 페이지에 맞는 사이즈로 사용 가능합니다.
- figma 상 content가 들어가는 size가 제각각이라 우선 1200px 사이즈로 맞춰서 제작했습니다.
- authContainer 따로 제작하려 하였으나 그냥 하나의 컴포넌트만 사용하는게 나을 것 같아서 로그인 회원가입 페이지에서는 container에 max-width + 외부에 하나 더 감싸서 flex로 중앙 정렬해서 사용하면 될 것 같습니다.
- 반응형도 페이지 별로 외부 padding이 달라서 mobile 16px tablet 24px desktop 0(m-auto로 중앙 정렬)으로 맞춰놨습니다.
- 사용방법
```
<Container>{children}</Container>
<Container className='max-w-200'> // 사용하는 곳에서 style overriding
```

## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.
(예: 이 로직을 훅으로 분리하는 게 맞는지 확신이 안 섭니다. / A방식과 B방식 중 성능 때문에 A를 택했는데 의견 궁금합니다.)

어떤걸 추가하면 더 범용적인 Container로 사용될 수 있을까요?

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
Closes #31 

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)
- 기본 형태(랜딩 페이지 하단 이미지, 리스트 페이지, 와인 상세 페이지)
![Container](https://github.com/user-attachments/assets/1253259a-4a67-4cd5-baa7-4580e49928bd)


- max-w-200으로 overriding(내 프로필 페이지의 각 탭)
![Container-max-w-200](https://github.com/user-attachments/assets/33939472-86de-49d6-b792-6f09265a34e9)
[AI로 test code 생성해서 작업했습니다.]
