### PR TITLE
feat: 사용자 인증을 위한 authprovider 기초작업

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,11 @@
-import "@/styles/globals.css";
-import type { AppProps } from "next/app";
+import '@/styles/globals.css';
+import type { AppProps } from 'next/app';
+import { AuthProvider } from '@/providers/Auth/AuthProvider';
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <AuthProvider>
+      <Component {...pageProps} />
+    </AuthProvider>
+  );
 }

--- a/providers/Auth/AuthProvider.tsx
+++ b/providers/Auth/AuthProvider.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useState } from 'react';
+import type { ReactNode } from 'react';
+
+import { AuthContextValue, User } from './types';
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+const DUMMY_USER: User = {
+  id: 99999999999,
+  nickname: '더미데이터',
+  image: Math.random() > 0.5 ? 'https://loremflickr.com/300/300' : null,
+};
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
+
+  const login = () => {
+    setIsLoggedIn(true);
+    setUser(DUMMY_USER);
+
+    console.log('로그인 되었습니다.');
+  };
+
+  const logout = () => {
+    setIsLoggedIn(false);
+    setUser(null);
+
+    console.log('로그아웃 되었습니다.');
+  };
+
+  const value = {
+    isLoggedIn,
+    user,
+    login,
+    logout,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('AuthProvider 내부에서만 사용할 수 있습니다.');
+  }
+  return context;
+};

--- a/providers/Auth/AuthProvider.tsx
+++ b/providers/Auth/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useState, useEffect } from 'react';
 import type { ReactNode } from 'react';
 
 import { AuthContextValue, User } from './types';
@@ -13,24 +13,18 @@ const DUMMY_USER: User = {
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
-  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
 
   const login = () => {
-    setIsLoggedIn(true);
     setUser(DUMMY_USER);
-
-    console.log('로그인 되었습니다.');
   };
 
   const logout = () => {
-    setIsLoggedIn(false);
     setUser(null);
-
-    console.log('로그아웃 되었습니다.');
   };
 
   const value = {
-    isLoggedIn,
+    isLoading,
     user,
     login,
     logout,

--- a/providers/Auth/types.ts
+++ b/providers/Auth/types.ts
@@ -5,7 +5,7 @@ export interface User {
 }
 
 export interface AuthContextValue {
-  isLoggedIn: boolean | null;
+  isLoading: boolean;
   user: User | null;
   login: () => void;
   logout: () => void;

--- a/providers/Auth/types.ts
+++ b/providers/Auth/types.ts
@@ -1,0 +1,12 @@
+export interface User {
+  id: number;
+  nickname: string;
+  image: string | null;
+}
+
+export interface AuthContextValue {
+  isLoggedIn: boolean | null;
+  user: User | null;
+  login: () => void;
+  logout: () => void;
+}


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

- 사용자 인증을 위한 AuthProvider 를 만들었습니다.
- 기초작업으로 로그인시 더미데이터를 채웠습니다.
- 50% 확률로 프로필 이미지 여부를 결정하였습니다.

## 같이 고민해 주세요 (리뷰 포인트)

providers 디렉토리를 만들고 그 안에 관련된 디렉토리를 만들어서 관리하도록 했습니다.
추가로 더 사용할 전역 상태관리가 있다면 테마정도가 추가될거같은데 현재 구조가 과한느낌입니다.

providers 안에 types 폴더만 두고 타입을 한곳에 모아두고, provider는 디렉토리에 그대로 둘지, 아니면 디렉토리 단위로 묶어서 정리할지 고민입니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #39 )

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)
