### PR TITLE
feat: 로그인 API Proxy

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,11 @@
-import "@/styles/globals.css";
-import type { AppProps } from "next/app";
+import '@/styles/globals.css';
+import type { AppProps } from 'next/app';
+import { AuthProvider } from '@/providers/Auth/AuthProvider';
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <AuthProvider>
+      <Component {...pageProps} />
+    </AuthProvider>
+  );
 }

--- a/pages/api/auth/logout.ts
+++ b/pages/api/auth/logout.ts
@@ -1,0 +1,3 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {}

--- a/pages/api/auth/signIn.ts
+++ b/pages/api/auth/signIn.ts
@@ -1,0 +1,54 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+
+  const BaseURL = process.env.API_URL;
+
+  if (!BaseURL) {
+    return res.status(500).json({ message: 'API_URL이 설정되지 않았습니다.' });
+  }
+
+  try {
+    const { email, password } = req.body;
+
+    if (!email || !password) {
+      return res.status(400).json({ message: 'Bad Request' });
+    }
+
+    const response = await fetch(`${BaseURL}/auth/signIn`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ email, password }),
+    });
+
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 400) {
+        return res.status(401).json({ message: '이메일 또는 비밀번호가 일치하지 않습니다.' });
+      }
+    }
+
+    const data = await response.json();
+
+    const isProd = process.env.NODE_ENV === 'production';
+    const cookieBase = `Path=/; HttpOnly; SameSite=Lax${isProd ? '; Secure' : ''}`;
+
+    res.setHeader('Set-Cookie', [
+      `accessToken=${data.accessToken}; Max-Age=${30 * 60}; ${cookieBase}`,
+      `refreshToken=${data.refreshToken}; Max-Age=${7 * 24 * 60 * 60}; ${cookieBase}`,
+    ]);
+
+    return res.status(200).json({
+      id: data.user.id,
+      nickname: data.user.nickname,
+      image: data.user.image,
+    });
+  } catch (error) {
+    console.error('Error signing in:', error);
+    return res.status(500).json({ message: '서버 오류가 발생했습니다.' });
+  }
+}

--- a/pages/api/auth/signup.ts
+++ b/pages/api/auth/signup.ts
@@ -1,0 +1,3 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {}

--- a/providers/Auth/AuthProvider.tsx
+++ b/providers/Auth/AuthProvider.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useState } from 'react';
+import type { ReactNode } from 'react';
+
+import { AuthContextValue, User } from './types';
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+const DUMMY_USER: User = {
+  id: 99999999999,
+  nickname: '더미데이터',
+  image: Math.random() > 0.5 ? 'https://loremflickr.com/300/300' : null,
+};
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
+
+  const login = () => {
+    setIsLoggedIn(true);
+    setUser(DUMMY_USER);
+
+    console.log('로그인 되었습니다.');
+  };
+
+  const logout = () => {
+    setIsLoggedIn(false);
+    setUser(null);
+
+    console.log('로그아웃 되었습니다.');
+  };
+
+  const value = {
+    isLoggedIn,
+    user,
+    login,
+    logout,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('AuthProvider 내부에서만 사용할 수 있습니다.');
+  }
+  return context;
+};

--- a/providers/Auth/AuthProvider.tsx
+++ b/providers/Auth/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useState, useEffect } from 'react';
 import type { ReactNode } from 'react';
 
 import { AuthContextValue, User } from './types';
@@ -13,24 +13,18 @@ const DUMMY_USER: User = {
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
-  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
 
   const login = () => {
-    setIsLoggedIn(true);
     setUser(DUMMY_USER);
-
-    console.log('로그인 되었습니다.');
   };
 
   const logout = () => {
-    setIsLoggedIn(false);
     setUser(null);
-
-    console.log('로그아웃 되었습니다.');
   };
 
   const value = {
-    isLoggedIn,
+    isLoading,
     user,
     login,
     logout,

--- a/providers/Auth/types.ts
+++ b/providers/Auth/types.ts
@@ -5,7 +5,7 @@ export interface User {
 }
 
 export interface AuthContextValue {
-  isLoggedIn: boolean | null;
+  isLoading: boolean;
   user: User | null;
   login: () => void;
   logout: () => void;

--- a/providers/Auth/types.ts
+++ b/providers/Auth/types.ts
@@ -1,0 +1,12 @@
+export interface User {
+  id: number;
+  nickname: string;
+  image: string | null;
+}
+
+export interface AuthContextValue {
+  isLoggedIn: boolean | null;
+  user: User | null;
+  login: () => void;
+  logout: () => void;
+}


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

- BFF 패턴을 적용한 로그인 API를 구현하였으며, 클라이언트와 외부 API 서버 사이에서 보안을 강화하기 위한 proxy 레이어를 추가했습니다.
- HttpOnly 쿠키 기반으로 저장하도록 적용했습니다.
- 클라이언트로 반환되는 응답에서 불필요한 액세스 토큰은 제거하고, 필요한 데이터만 전달하도록 수정하였습니다.

## 같이 고민해 주세요 (리뷰 포인트)

로그인 실패 시 기존에는 이메일 불일치, 비밀번호 불일치 등 구분하여 제공해줬지만, 이메일 또는 비밀번호가 일치하지 않습니다 로 통합하였습니다.

기존 방식으로 제공했을 경우 무차별 대입공격을 이용하여 사용자의 이메일을 얻을 수 있어서 해당 부분에 대한 방어조치인데 사용자 경험측면에서 너무 불친절하진않은지 의견 부탁드립니다.

에러 핸들링은 400/401 위주로 처리했습니다. 이 외에 에러가 발생했을 경우에는 아직 대처하진않았습니다. 이 부분에서 어떤식으로 더 대응할 수 있을지 의견 부탁드립니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #42 )

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)
