### PR TITLE
feat: label 및 formfield 컴포넌트 구현

### DIFF
--- a/components/common/form/FormField.tsx
+++ b/components/common/form/FormField.tsx
@@ -1,28 +1,23 @@
-import Input from '@/components/common/ui/Input';
-import Label from '@/components/common/ui/Label';
 import { cn } from '@/utils/cn';
+import Input from '../ui/Input';
+import Label from '../ui/Label';
 
-interface FormFieldProps extends React.ComponentPropsWithoutRef<typeof Input> {
+interface FormFieldProps extends React.ComponentPropsWithRef<typeof Input> {
   label?: string;
   error?: string;
-  onSearch?: (value: string) => void;
 }
 
-const FormField = ({ label, error, onSearch, id, className, ...props }: FormFieldProps) => {
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && onSearch) {
-      e.preventDefault();
-      onSearch(e.currentTarget.value);
-    }
-    props.onKeyDown?.(e);
-  };
-
+const FormField = ({ label, ref, error, id, className, ...props }: FormFieldProps) => {
+  const inputStatus = error ? 'error' : (props.status ?? 'default');
   return (
     <div className={cn('flex flex-col gap-1.5 w-full', className)}>
       {label && <Label htmlFor={id}>{label}</Label>}
-      <Input id={id} status={error ? 'error' : props.status} onKeyDown={handleKeyDown} {...props} />
-
-      {error && <span className="text-xs text-destructive font-medium ml-1">{error}</span>}
+      <Input ref={ref} id={id} status={inputStatus} {...props} />
+      {error && (
+        <p className="ml-1 text-xs text-destructive" aria-live="polite">
+          {error}
+        </p>
+      )}
     </div>
   );
 };

--- a/components/common/form/FormField.tsx
+++ b/components/common/form/FormField.tsx
@@ -1,0 +1,30 @@
+import Input from '@/components/common/ui/Input';
+import Label from '@/components/common/ui/Label';
+import { cn } from '@/utils/cn';
+
+interface FormFieldProps extends React.ComponentPropsWithoutRef<typeof Input> {
+  label?: string;
+  error?: string;
+  onSearch?: (value: string) => void;
+}
+
+const FormField = ({ label, error, onSearch, id, className, ...props }: FormFieldProps) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && onSearch) {
+      e.preventDefault();
+      onSearch(e.currentTarget.value);
+    }
+    props.onKeyDown?.(e);
+  };
+
+  return (
+    <div className={cn('flex flex-col gap-1.5 w-full', className)}>
+      {label && <Label htmlFor={id}>{label}</Label>}
+      <Input id={id} status={error ? 'error' : props.status} onKeyDown={handleKeyDown} {...props} />
+
+      {error && <span className="text-xs text-destructive font-medium ml-1">{error}</span>}
+    </div>
+  );
+};
+
+export default FormField;

--- a/components/common/ui/Label.tsx
+++ b/components/common/ui/Label.tsx
@@ -1,0 +1,18 @@
+import { ComponentPropsWithRef } from 'react';
+import { cn } from '@/utils/cn';
+
+type LabelProps = ComponentPropsWithRef<'label'>;
+
+const Label = ({ children, className, ref, ...props }: LabelProps) => {
+  return (
+    <label
+      ref={ref}
+      className={cn('text-sm font-medium text-foreground cursor-pointer', className)}
+      {...props}
+    >
+      {children}
+    </label>
+  );
+};
+
+export default Label;


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.

- Label 컴포넌트, 라벨과 에러 메시지 처리, 검색이 포함된 FormField 및 를 구현했습니다.


## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.

- 폼필드 역할은 어디까지일까 고민이였습니다. 처음에는 검색 로직(onSearch)을 넣고 엔터키 기능까지 넣었다 오로지 폼필드는 라벨, 인풋, 에러 메시지를 안전하게 연결해 보여주는 역할만 할 수있도록 다시 설계했습니다
- Label 컴포넌트: htmlFor 속성을 통해 Input과 연결될 수 있도록 설계
-  삼항 연산자였던 계산 연산자 로직은 내부에 두지 않고 상단 변수(inputStatus)로 추출했습니다. 

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #46)

## 테스트 결과 (스크린샷)
<img width="383" height="461" alt="스크린샷 2026-02-09 오후 2 09 06" src="https://github.com/user-attachments/assets/79576039-3774-412e-a225-c08ccb4d1a05" />

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)
