### PR TITLE
refactor: 아바타 컴포넌트 스타일 반영 및 최적화 추가

### DIFF
--- a/components/common/ui/Avatar/Avatar.tsx
+++ b/components/common/ui/Avatar/Avatar.tsx
@@ -1,4 +1,7 @@
 import { createContext, useContext, useState, useEffect } from 'react';
+import Image from 'next/image';
+
+import { cn } from '@/utils/cn';
 
 import type {
   AvatarStatus,
@@ -18,7 +21,7 @@ const useAvatar = () => {
   return ctx;
 };
 
-function Avatar({ children, ...props }: AvatarProps) {
+function Avatar({ children, className, ...props }: AvatarProps) {
   const [status, setStatus] = useState<AvatarStatus>('loading');
 
   const value = {
@@ -28,47 +31,59 @@ function Avatar({ children, ...props }: AvatarProps) {
 
   return (
     <AvatarContext.Provider value={value}>
-      <span {...props}>{children}</span>
+      <div
+        className={cn(
+          'relative flex items-center justify-center overflow-hidden rounded-full w-10 h-10',
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
     </AvatarContext.Provider>
   );
 }
 
-function AvatarImage({ src, alt, ...props }: AvatarImageProps) {
+function AvatarImage({ src, alt, sizes, className, ...props }: AvatarImageProps) {
   const { status, setStatus } = useAvatar();
 
   useEffect(() => {
-    let cancelled = false;
+    if (!src) return setStatus('error');
 
     setStatus('loading');
-
-    const img = new Image();
-
-    img.onload = () => {
-      if (!cancelled) setStatus('loaded');
-    };
-
-    img.onerror = () => {
-      if (!cancelled) setStatus('error');
-    };
-
-    img.src = src;
-
-    return () => {
-      cancelled = true;
-    };
   }, [src, setStatus]);
 
-  if (status !== 'loaded') return null;
+  if (status === 'error') return null;
 
-  // eslint-disable-next-line @next/next/no-img-element
-  return <img src={src} alt={alt} {...props} />;
+  return (
+    <Image
+      className={cn('object-cover', className)}
+      onError={() => setStatus('error')}
+      onLoad={() => setStatus('loaded')}
+      src={src}
+      alt={alt}
+      fill
+      sizes={sizes || '40px'}
+      {...props}
+    />
+  );
 }
 
-function AvatarFallback({ children, ...props }: AvatarFallbackProps) {
+function AvatarFallback({ children, className, ...props }: AvatarFallbackProps) {
   const { status } = useAvatar();
   if (status === 'loaded') return null;
 
-  return <span {...props}>{children}</span>;
+  return (
+    <span
+      className={cn(
+        'bg-muted text-muted-foreground flex size-full items-center justify-center rounded-full text-xs',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
 }
 
 export { Avatar, AvatarImage, AvatarFallback };

--- a/components/common/ui/Avatar/types.ts
+++ b/components/common/ui/Avatar/types.ts
@@ -1,4 +1,5 @@
 import type { ComponentPropsWithoutRef, ReactNode, Dispatch, SetStateAction } from 'react';
+import type Image from 'next/image';
 
 export type AvatarStatus = 'loading' | 'loaded' | 'error';
 
@@ -7,15 +8,18 @@ export interface AvatarContextValue {
   setStatus: Dispatch<SetStateAction<AvatarStatus>>;
 }
 
-export type AvatarProps = ComponentPropsWithoutRef<'span'> & {
+export type AvatarProps = ComponentPropsWithoutRef<'div'> & {
+  className?: string;
   children?: ReactNode;
 };
 
-export type AvatarImageProps = Omit<ComponentPropsWithoutRef<'img'>, 'children'> & {
-  src: string;
+export type AvatarImageProps = ComponentPropsWithoutRef<typeof Image> & {
   alt?: string;
+  className?: string;
+  sizes?: string;
 };
 
 export type AvatarFallbackProps = ComponentPropsWithoutRef<'span'> & {
   children?: ReactNode;
+  className?: string;
 };


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

- 기존 img 태그를 이용한 아바타 컴포넌트를 Image 로 변경했습니다.
- 누락된 스타일을 적용했습니다.

## 같이 고민해 주세요 (리뷰 포인트)

- 프로필사진은 유저가 직접 업로드하는 이미지인 만큼 일반 img 말고 Image 태그를 이용하여 최적화를 하도록 지정했습니다.
- 무료티어에서는 월 1,000회만 제공해주는걸로 알고있고, 작은 이미지인 만큼 최적화를 적용해야할지 고민입니다.
- Image 태그는 type 정의를 ComponentPropsWithoutRef<typeof Image> 가 맞는지 모르겠습니다. 공식문서에도 타입에 대한 내용이 없어서 넣어봤습니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #60 )

## 테스트 결과 (스크린샷)

<img width="209" height="414" alt="image" src="https://github.com/user-attachments/assets/29bba236-45a4-4b4c-9023-cb34918b3457" />

```js
<Avatar className="w-[200px] h-[200px]">
        <AvatarImage src={logo} alt="프로필이미지" />
        <AvatarFallback>프로필사진 없으면 샘플이미지...</AvatarFallback>
</Avatar>
<Avatar className="w-[200px] h-[200px]">
        <AvatarImage src="../assets/icon/icon-input-error.svg" alt="프로필이미지" />
        <AvatarFallback>CN</AvatarFallback>
</Avatar>
```
