### PR TITLE
feat: signIn api proxy 타입정의 및 쿠키 생성 및 제거 로직 분리

### DIFF
--- a/components/common/ui/Avatar/Avatar.tsx
+++ b/components/common/ui/Avatar/Avatar.tsx
@@ -1,4 +1,7 @@
 import { createContext, useContext, useState, useEffect } from 'react';
+import Image from 'next/image';
+
+import { cn } from '@/utils/cn';
 
 import type {
   AvatarStatus,
@@ -18,7 +21,7 @@ const useAvatar = () => {
   return ctx;
 };
 
-function Avatar({ children, ...props }: AvatarProps) {
+function Avatar({ children, className, ...props }: AvatarProps) {
   const [status, setStatus] = useState<AvatarStatus>('loading');
 
   const value = {
@@ -28,47 +31,59 @@ function Avatar({ children, ...props }: AvatarProps) {
 
   return (
     <AvatarContext.Provider value={value}>
-      <span {...props}>{children}</span>
+      <div
+        className={cn(
+          'relative flex items-center justify-center overflow-hidden rounded-full w-10 h-10',
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
     </AvatarContext.Provider>
   );
 }
 
-function AvatarImage({ src, alt, ...props }: AvatarImageProps) {
+function AvatarImage({ src, alt, sizes, className, ...props }: AvatarImageProps) {
   const { status, setStatus } = useAvatar();
 
   useEffect(() => {
-    let cancelled = false;
+    if (!src) return setStatus('error');
 
     setStatus('loading');
-
-    const img = new Image();
-
-    img.onload = () => {
-      if (!cancelled) setStatus('loaded');
-    };
-
-    img.onerror = () => {
-      if (!cancelled) setStatus('error');
-    };
-
-    img.src = src;
-
-    return () => {
-      cancelled = true;
-    };
   }, [src, setStatus]);
 
-  if (status !== 'loaded') return null;
+  if (status === 'error') return null;
 
-  // eslint-disable-next-line @next/next/no-img-element
-  return <img src={src} alt={alt} {...props} />;
+  return (
+    <Image
+      className={cn('object-cover', className)}
+      onError={() => setStatus('error')}
+      onLoad={() => setStatus('loaded')}
+      src={src}
+      alt={alt}
+      fill
+      sizes={sizes || '40px'}
+      {...props}
+    />
+  );
 }
 
-function AvatarFallback({ children, ...props }: AvatarFallbackProps) {
+function AvatarFallback({ children, className, ...props }: AvatarFallbackProps) {
   const { status } = useAvatar();
   if (status === 'loaded') return null;
 
-  return <span {...props}>{children}</span>;
+  return (
+    <span
+      className={cn(
+        'bg-muted text-muted-foreground flex size-full items-center justify-center rounded-full text-xs',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
 }
 
 export { Avatar, AvatarImage, AvatarFallback };

--- a/components/common/ui/Avatar/types.ts
+++ b/components/common/ui/Avatar/types.ts
@@ -1,4 +1,5 @@
 import type { ComponentPropsWithoutRef, ReactNode, Dispatch, SetStateAction } from 'react';
+import type Image from 'next/image';
 
 export type AvatarStatus = 'loading' | 'loaded' | 'error';
 
@@ -7,15 +8,18 @@ export interface AvatarContextValue {
   setStatus: Dispatch<SetStateAction<AvatarStatus>>;
 }
 
-export type AvatarProps = ComponentPropsWithoutRef<'span'> & {
+export type AvatarProps = ComponentPropsWithoutRef<'div'> & {
+  className?: string;
   children?: ReactNode;
 };
 
-export type AvatarImageProps = Omit<ComponentPropsWithoutRef<'img'>, 'children'> & {
-  src: string;
+export type AvatarImageProps = ComponentPropsWithoutRef<typeof Image> & {
   alt?: string;
+  className?: string;
+  sizes?: string;
 };
 
 export type AvatarFallbackProps = ComponentPropsWithoutRef<'span'> & {
   children?: ReactNode;
+  className?: string;
 };

--- a/lib/auth/cookie.ts
+++ b/lib/auth/cookie.ts
@@ -1,0 +1,11 @@
+export const getCookieOptions = (maxAge: number) => {
+  const isProd = process.env.NODE_ENV === 'production';
+  return `Path=/; HttpOnly; SameSite=Lax; Max-Age=${maxAge}; ${isProd ? '; Secure' : ''}`;
+};
+
+export const setCookie = {
+  accessToken: (token: string) => `accessToken=${token}; ${getCookieOptions(60 * 60 * 24 * 7)}`,
+  refreshToken: (token: string) => `refreshToken=${token}; ${getCookieOptions(60 * 60 * 24 * 7)}`,
+  clearAccessToken: () => `accessToken=; Path=/; Max-Age=0`,
+  clearRefreshToken: () => `refreshToken=; Path=/; Max-Age=0`,
+};

--- a/pages/api/auth/signIn.ts
+++ b/pages/api/auth/signIn.ts
@@ -1,24 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
+const BASE_URL = process.env.API_URL;
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
 
-  const BaseURL = process.env.API_URL;
-
-  if (!BaseURL) {
-    return res.status(500).json({ message: 'API_URL이 설정되지 않았습니다.' });
-  }
-
   try {
     const { email, password } = req.body;
 
-    if (!email || !password) {
-      return res.status(400).json({ message: 'Bad Request' });
-    }
-
-    const response = await fetch(`${BaseURL}/auth/signIn`, {
+    const response = await fetch(`${BASE_URL}/auth/signIn`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -30,6 +22,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       if (response.status === 401 || response.status === 400) {
         return res.status(401).json({ message: '이메일 또는 비밀번호가 일치하지 않습니다.' });
       }
+
+      return res.status(response.status).json({ message: '서버 오류가 발생했습니다.' });
     }
 
     const data = await response.json();

--- a/types/auth/auth.ts
+++ b/types/auth/auth.ts
@@ -1,0 +1,22 @@
+export interface SignInRequest {
+  email: string;
+  password: string;
+}
+
+export interface SignInResponse {
+  accessToken: string;
+  refreshToken: string;
+  user: {
+    id: number;
+    nickname: string;
+    image: null | string;
+    updatedAt: string;
+    createdAt: string;
+  };
+}
+
+export interface ClientAuthResponse {
+  id: string;
+  nickname: string;
+  image: string | null;
+}


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

- API Proxy 를 추가하여 HTTP Only  쿠키를 생성하도록 하였습니다.
- 쿠키 생성 및 삭제 로직을 분리했습니다.
- 기존 API Proxy 에서 최소방어선으로 추가한 빈값 검증 부분을 제거하고 API 서버에서 체크하도록 변경했습니다.

## 같이 고민해 주세요 (리뷰 포인트)

- 기존 API 서버에서 아이디가 틀린 경우에는 아이디가 틀렸습니다. 비밀번호가 틀린 경우 비밀번호가 틀렸습니다. 로 전달해주던 부분을 하나로 통합하여 이메일 또는 비밀번호가 일치하지 않습니다로 변경하였습니다. 틀린부분을 바로 알려주면 보안적인 부분에서 문제가될것같아서 하나로 통합된 메시지로 제공하고있는데 이 부분이 UI/UX 적으로 적합한지 확인부탁드립니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #64 )

## 테스트 결과 (스크린샷)

<img width="1517" height="288" alt="image" src="https://github.com/user-attachments/assets/85bfd79f-540a-4083-9354-5978becd257f" />
