### PR TITLE
feat: catch-all Segments setup

### DIFF
--- a/pages/api/[...path].ts
+++ b/pages/api/[...path].ts
@@ -1,5 +1,0 @@
-import { NextApiRequest, NextApiResponse } from 'next';
-
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  res.status(200).json({ message: 'success' });
-}

--- a/pages/api/proxy/[...path].ts
+++ b/pages/api/proxy/[...path].ts
@@ -1,0 +1,55 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const BASE_URL = process.env.API_URL;
+const ALLOWED_METHODS = ['GET', 'POST', 'PATCH', 'DELETE'];
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!ALLOWED_METHODS.includes(req.method as string)) {
+    res.setHeader('Allow', ALLOWED_METHODS.join(', '));
+    return res.status(405).json({ message: '허용된 메소드가 아닙니다.' });
+  }
+
+  try {
+    const { path, ...query } = req.query;
+    const pathString = Array.isArray(path) ? path.join('/') : path;
+    const params = new URLSearchParams();
+
+    Object.entries(query).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach(v => v != null && params.append(key, v));
+      } else if (value != null) {
+        params.append(key, value);
+      }
+    });
+
+    const qs = params.toString();
+    const url = `${BASE_URL}/${pathString}${qs ? `?${qs}` : ''}`;
+
+    const { accessToken } = req.cookies;
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    if (accessToken) {
+      headers['Authorization'] = `Bearer ${accessToken}`;
+    }
+
+    const options = {
+      method: req.method,
+      headers,
+      body:
+        req.method === 'POST' || req.method === 'PATCH'
+          ? JSON.stringify(req.body ?? {})
+          : undefined,
+    };
+
+    const response = await fetch(url, options);
+
+    const data = await response.json();
+
+    return res.status(response.status).json(data);
+  } catch (error) {
+    return res.status(500).json({ message: '서버 오류가 발생했습니다.', error });
+  }
+}


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

- Auth 외에 다른 api proxy는 catch-all Segments 를 이용하여 통과하도록 설계했습니다.

## 같이 고민해 주세요 (리뷰 포인트)

- 멘토님의 피드백을 반영하여 api proxy의 역할에 충실하도록 받은걸 그대로 돌려주도록 처리했습니다.
- 아직 401 에러 발생시 다시 갱신하는 로직은 추가하지않았습니다.  아직 구현로직을 체크중입니다.
- 기존에는 /api/path로 요청보낼 수 있도록 처리했으나, proxy를 한번 거쳐서 간다는 의미를 명확하게 하기 위하여 /api/proxy/ 로 구조를 변경했습니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #71 )

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)
