### PR TITLE
feat: dialog 컴포넌트 기초작업

### DIFF
--- a/components/common/ui/Dialog/Dialog.tsx
+++ b/components/common/ui/Dialog/Dialog.tsx
@@ -1,0 +1,141 @@
+import { createContext, useContext, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import Button from '../Button';
+
+import type { ReactPortal, PropsWithChildren, MouseEvent, SetStateAction } from 'react';
+import type {
+  DialogContextValue,
+  DialogProps,
+  DialogTriggerProps,
+  DialogContentProps,
+} from './types';
+
+import { cn } from '@/utils/cn';
+
+const DialogContext = createContext<DialogContextValue | null>(null);
+
+const useDialog = () => {
+  const ctx = useContext(DialogContext);
+  if (!ctx) {
+    throw new Error('Dialog 컴포넌트 내부에서만 사용');
+  }
+  return ctx;
+};
+
+const useDialogState = () => {
+  const [open, setOpen] = useState(false);
+
+  const onOpen = () => setOpen(true);
+  const onClose = () => setOpen(false);
+
+  return { open, onOpenChange: setOpen, onOpen, onClose };
+};
+
+function Dialog({ children, open: controlledOpen, onOpenChange }: DialogProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+
+  const isOpen = controlledOpen !== undefined ? controlledOpen : uncontrolledOpen;
+
+  const handleOpenChange = (value: SetStateAction<boolean>) => {
+    if (controlledOpen !== undefined) {
+      onOpenChange?.(value);
+    } else {
+      setUncontrolledOpen(value);
+    }
+  };
+
+  const value = {
+    open: isOpen,
+    setOpen: handleOpenChange,
+  };
+
+  return <DialogContext.Provider value={value}>{children}</DialogContext.Provider>;
+}
+
+function DialogTrigger({ children, onClick }: DialogTriggerProps) {
+  const { setOpen } = useDialog();
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    onClick?.(e);
+    setOpen(true);
+  };
+
+  return <Button onClick={handleClick}>{children}</Button>;
+}
+
+function DialogPortal({ children }: PropsWithChildren): ReactPortal | null {
+  if (typeof window === 'undefined') return null;
+  return createPortal(children, document.body);
+}
+
+function DialogClose({ children, className }: DialogContentProps) {
+  const { setOpen } = useDialog();
+  return (
+    <Button className={cn('', className)} onClick={() => setOpen(false)}>
+      {children}
+    </Button>
+  );
+}
+
+function DialogOverlay() {
+  const { setOpen } = useDialog();
+  return <div className="fixed inset-0 isolate z-50 bg-black/50" onClick={() => setOpen(false)} />;
+}
+
+function DialogContent({ children, className }: DialogContentProps) {
+  const { open } = useDialog();
+  if (!open) return null;
+
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <div
+        className={cn(
+          'fixed z-50 bg-white shadow-lg transition-all flex flex-col',
+          'bottom-0 left-0 right-0 w-full rounded-t-[20px] max-h-[90vh]',
+          'md:top-1/2 md:left-1/2 md:bottom-auto md:w-full md:max-w-md md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-[12px] md:max-h-[85vh]',
+          className
+        )}
+      >
+        <div className="mx-auto my-3 h-1.5 w-20 rounded-full bg-gray-300 md:hidden" />
+        {children}
+      </div>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ children, className }: DialogContentProps) {
+  return <div className={cn('flex flex-col gap-2 p-4', className)}>{children}</div>;
+}
+
+function DialogBody({ children, className }: DialogContentProps) {
+  return <div className={cn('flex-1 overflow-y-auto p-4', className)}>{children}</div>;
+}
+
+function DialogFooter({ children, className }: DialogContentProps) {
+  return <div className={cn('flex flex-col gap-2 p-4', className)}>{children}</div>;
+}
+
+function DialogTitle({ children, className }: DialogContentProps) {
+  return <h2 className={cn('text-lg font-semibold', className)}>{children}</h2>;
+}
+
+function DialogDescription({ children, className }: DialogContentProps) {
+  return <p className={cn('text-sm text-gray-600', className)}>{children}</p>;
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogBody,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+  useDialogState,
+};

--- a/components/common/ui/Dialog/index.ts
+++ b/components/common/ui/Dialog/index.ts
@@ -1,0 +1,14 @@
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogBody,
+  DialogFooter,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+  useDialogState,
+} from './Dialog';

--- a/components/common/ui/Dialog/types.ts
+++ b/components/common/ui/Dialog/types.ts
@@ -1,0 +1,22 @@
+import type { ReactNode, Dispatch, SetStateAction, MouseEventHandler } from 'react';
+
+export interface DialogContextValue {
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+export interface DialogProps {
+  children: ReactNode;
+  open?: boolean;
+  onOpenChange?: Dispatch<SetStateAction<boolean>>;
+}
+
+export interface DialogTriggerProps {
+  children: ReactNode;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+}
+
+export interface DialogContentProps {
+  children: ReactNode;
+  className?: string;
+}


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

- dialog 컴포넌트 기초 작업을 하였습니다.
- 일부 타입은 AI의 도움을 받았습니다.
- 트리거, 닫기 버튼은 기존 Button 컴포넌트를 사용하도록 처리했습니다.
- 트리거버튼에 실수로 className을 안받았습니다. 추후 개선하도록 하겠습니다.

## 같이 고민해 주세요 (리뷰 포인트)

[https://ko.react.dev/reference/react/cloneElement](https://ko.react.dev/reference/react/cloneElement)
레거시로 들어간 cloneElement 대신 context, hooks 2가지 방식으로 제어할 수 있도록 처리하였습니다.

렌더링 prop 로 전달하기는 아직 제대로 이해하지못하여 적용하지않았지만, context 와 hook 방식으로 제어하는게 더 좋다고 판단해서 prop 방식은 배제하였습니다.

해당 학습을 하는 과정에서 contextAPI의 활용에 대해 더 학습하였으며, provider 내부에 있다면 부모의 context를 기반으로 작동하기에 useDialog 를 이용해서 컨트롤 할 수 있었습니다.

컴파운드 컴포넌트 패턴을 적용하며, 제어방식과 비제어 방식에 대해 더 공부할 수 있었습니다.

## 추가 학습 포인트

- focus trap
- 모바일 bar를 이용한 swipe
- 키보드 제어

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #76 )

## 테스트 결과 (스크린샷)

<img width="485" height="780" alt="image" src="https://github.com/user-attachments/assets/5f087ae7-d4c0-4932-83db-3ba796a3c72d" />

<img width="614" height="885" alt="image" src="https://github.com/user-attachments/assets/eafad25e-4b99-41f3-9cf4-a326f353ff13" />

