### PR TITLE
feat: 공통 컴포넌트 chip 작업

### DIFF
--- a/components/common/ui/chip.tsx
+++ b/components/common/ui/chip.tsx
@@ -1,3 +1,5 @@
+import { cn } from '@/utils/cn';
+
 interface ChipProps {
   label: string;
   selected: boolean;
@@ -6,14 +8,19 @@ interface ChipProps {
 
 export default function Chip({ label, selected = false, onClick }: ChipProps) {
   const baseStyle =
-    'flex items-center justify-center w-fit px-[18px] py-3 rounded-full border text-sm transition-all cursor-pointer font-medium';
-
-  const statusStyle = selected
-    ? 'bg-[#484746] text-white border-[#484746]'
-    : 'bg-white text-[#31302F] border-[#F2F2F2]';
+    'flex items-center justify-center w-fit px-[18px] py-3 rounded-full border text-base font-medium transition-all cursor-pointer';
 
   return (
-    <button type="button" className={`${baseStyle} ${statusStyle}`} onClick={onClick}>
+    <button
+      type="button"
+      className={cn(
+        baseStyle,
+        selected
+          ? 'bg-primary text-primary-foreground border-primary'
+          : 'bg-white text-[#31302F] border-[#F2F2F2]'
+      )}
+      onClick={onClick}
+    >
       {label}
     </button>
   );

--- a/components/common/ui/chip.tsx
+++ b/components/common/ui/chip.tsx
@@ -1,12 +1,11 @@
 import { cn } from '@/utils/cn';
 
-interface ChipProps {
+interface ChipProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   label: string;
-  selected: boolean;
-  onClick: () => void;
+  selected?: boolean;
 }
 
-export default function Chip({ label, selected = false, onClick }: ChipProps) {
+export default function Chip({ label, selected = false, className, ...props }: ChipProps) {
   const baseStyle =
     'flex items-center justify-center w-fit px-[18px] py-3 rounded-full border text-base font-medium transition-all cursor-pointer';
 
@@ -17,9 +16,10 @@ export default function Chip({ label, selected = false, onClick }: ChipProps) {
         baseStyle,
         selected
           ? 'bg-primary text-primary-foreground border-primary'
-          : 'bg-white text-[#31302F] border-[#F2F2F2]'
+          : 'bg-white text-[#31302F] border-[#F2F2F2]',
+        className
       )}
-      onClick={onClick}
+      {...props}
     >
       {label}
     </button>

--- a/components/common/ui/chip.tsx
+++ b/components/common/ui/chip.tsx
@@ -1,0 +1,20 @@
+interface ChipProps {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+}
+
+export default function Chip({ label, selected = false, onClick }: ChipProps) {
+  const baseStyle =
+    'flex items-center justify-center w-fit px-[18px] py-3 rounded-full border text-sm transition-all cursor-pointer font-medium';
+
+  const statusStyle = selected
+    ? 'bg-[#484746] text-white border-[#484746]'
+    : 'bg-white text-[#31302F] border-[#F2F2F2]';
+
+  return (
+    <button type="button" className={`${baseStyle} ${statusStyle}`} onClick={onClick}>
+      {label}
+    </button>
+  );
+}

--- a/components/common/ui/chip.tsx
+++ b/components/common/ui/chip.tsx
@@ -7,20 +7,14 @@ interface ChipProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 
 export default function Chip({ label, selected = false, className, ...props }: ChipProps) {
   const baseStyle =
-    'flex items-center justify-center w-fit px-[18px] py-3 rounded-full border text-base font-medium transition-all cursor-pointer';
+    'px-[12px] py-[9px] text-sm md:px-[18px] md:py-3 md:text-base flex items-center justify-center w-fit rounded-full border font-medium transition-all cursor-pointer';
+
+  const variantStyle = selected
+    ? 'bg-primary text-primary-foreground border-primary'
+    : 'bg-white text-[#31302F] border-[#F2F2F2]';
 
   return (
-    <button
-      type="button"
-      className={cn(
-        baseStyle,
-        selected
-          ? 'bg-primary text-primary-foreground border-primary'
-          : 'bg-white text-[#31302F] border-[#F2F2F2]',
-        className
-      )}
-      {...props}
-    >
+    <button type="button" className={cn(baseStyle, variantStyle, className)} {...props}>
       {label}
     </button>
   );


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

- 공통 컴포넌트 chip 구현
- 인터페이스(label, seleted, onClick) 정의
- 피그마 디자인 반영
- 반응형 작업

## 같이 고민해 주세요 (리뷰 포인트)

- 필터 와인 타입을 가로로 놓게 되면서 사이즈 조절 이슈로 칩 내에 이미지를 없앴던 걸로 기억합니다! 혹시 이미지가 들어가는 다른 부분이 있다거나 제가 놓친 부분이 있다면 말씀해주세요.
- 칩 내부에서는 선택 여부에 따른 색상만 관리하고 다중선택이나 상태관리는 각 페이지에서 담당하는게 어떤가 하는 의견입니다. 더 좋은 의견이 있다면 말씀해주세요~

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
Closes #52

## 테스트 결과 (스크린샷)
md 사이즈
<img width="283" height="76" alt="image" src="https://github.com/user-attachments/assets/c0942d7b-aa9a-4c78-8701-94fbfedc16a7" />

모바일 사이즈
<img width="234" height="65" alt="image" src="https://github.com/user-attachments/assets/4c32ffdb-ad3b-459f-8f4f-84bfff809d09" />


