### PR TITLE
feat: 로그인페이지 초안작업

### DIFF
--- a/components/common/layout/AuthLayout.tsx
+++ b/components/common/layout/AuthLayout.tsx
@@ -1,0 +1,27 @@
+// components/common/layout/AuthLayout.tsx
+import { ReactNode } from 'react';
+import Image from 'next/image';
+import logoImg from '@/assets/logo/logo.png';
+
+interface AuthLayoutProps {
+  children: ReactNode;
+}
+
+export default function AuthLayout({ children }: AuthLayoutProps) {
+  return (
+    <div className="min-h-screen bg-secondary flex flex-col items-center pt-24 sm:pt-40 px-4">
+      <div className="w-full max-w-[500px] bg-white rounded-2xl py-12 px-5 sm:py-20 sm:px-12">
+        <div className="flex flex-col items-center mb-10 sm:mb-16">
+          <Image
+            className="brightness-0"
+            src={logoImg}
+            alt="Codeit Wine 로고"
+            width={104}
+            height={30}
+          />
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import AuthLayout from '@/components/common/layout/AuthLayout';
+import FormField from '@/components/common/form/FormField';
+import Button from '@/components/common/ui/Button';
+import Link from 'next/link';
+
+import { useAuth } from '@/providers/Auth/AuthProvider';
+
+export default function SignIn() {
+  const router = useRouter();
+  const { login } = useAuth();
+
+  const [values, setValues] = useState({
+    email: '',
+    password: '',
+  });
+
+  const handleChange = id => e => {
+    setValues(prev => ({
+      ...prev,
+      [id]: e,
+    }));
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    const res = await login(values);
+    if (res?.success) {
+      router.push('/');
+    }
+  };
+
+  return (
+    <AuthLayout>
+      <form onSubmit={handleSubmit} className="flex flex-col">
+        <div className="flex flex-col gap-6 mb-10">
+          <FormField
+            id="email"
+            label="이메일"
+            placeholder="이메일을 입력해주세요"
+            type="text"
+            onChange={handleChange('email')}
+          />
+
+          <FormField
+            id="password"
+            label="비밀번호"
+            placeholder="비밀번호를 입력해주세요"
+            type="password"
+            onChange={handleChange('password')}
+          />
+        </div>
+
+        <div className="flex flex-col gap-8">
+          <Button type="submit" className="h-[50px]">
+            로그인
+          </Button>
+
+          <div className="flex justify-center items-center gap-2 text-sm">
+            <span className="text-muted-foreground">계정이 없으신가요?</span>
+            <Link href="/auth/signup" className="text-primary underline font-medium">
+              회원가입하기
+            </Link>
+          </div>
+        </div>
+      </form>
+    </AuthLayout>
+  );
+}

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -1,55 +1,20 @@
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
-
 import AuthLayout from '@/components/common/layout/AuthLayout';
 import FormField from '@/components/common/form/FormField';
 import Button from '@/components/common/ui/Button';
 import Link from 'next/link';
 
-import { useAuth } from '@/providers/Auth/AuthProvider';
-
 export default function SignIn() {
-  const router = useRouter();
-  const { login } = useAuth();
-
-  const [values, setValues] = useState({
-    email: '',
-    password: '',
-  });
-
-  const handleChange = id => e => {
-    setValues(prev => ({
-      ...prev,
-      [id]: e,
-    }));
-  };
-
-  const handleSubmit = async e => {
-    e.preventDefault();
-    const res = await login(values);
-    if (res?.success) {
-      router.push('/');
-    }
-  };
-
   return (
     <AuthLayout>
-      <form onSubmit={handleSubmit} className="flex flex-col">
+      <form className="flex flex-col">
         <div className="flex flex-col gap-6 mb-10">
-          <FormField
-            id="email"
-            label="이메일"
-            placeholder="이메일을 입력해주세요"
-            type="text"
-            onChange={handleChange('email')}
-          />
+          <FormField id="email" label="이메일" placeholder="이메일을 입력해주세요" type="text" />
 
           <FormField
             id="password"
             label="비밀번호"
             placeholder="비밀번호를 입력해주세요"
             type="password"
-            onChange={handleChange('password')}
           />
         </div>
 


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- 로그인 페이지 UI 퍼블리싱
- API 호출 테스트
- 로고같은 경우에는 기본로고가 하얀색으로 css filter 로 색상을 뒤집었습니다.

## 같이 고민해 주세요 (리뷰 포인트)

- 아직 검증관련된 부분은 작업하지않았습니다. RHF + Zod를 도입하면 안전하게 에러 핸들링과 검증을 해결할 수 있지만, 추가적인 학습이 필요합니다. 
- 에러핸들링 방식을 선택해서 공통으로 사용할 수 있도록 hook으로 분리하고자 합니다.
  - Blur 시점에만 검증하며, 실시간 피드백은 제공하지않는다.
  - 처음 검증은 Blur 시점에 검증하고, 해당 필드에서 Blur 이벤트가 발생한 경우 touched 의 값을 변경, touched의 값이 true 인 경우 input event 검증 제공

- 아직 외부로그인은 작업하지않았습니다. API 등록이 필요합니다. 초기에 이야기했던 방식으로 다 같이 경험할 수 있도록 구글, 카카오, 페이스북 작업을 할지, 아니면 빠르게 적용할지 확인부탁드립니다.
- 로그인 및 회원가입같은 경우에는 전용 Layout을 추가했습니다. app router를 사용했다면 조금 더 간단한 방법으로 auth 디렉토리 안에 layout.tsx 를 만들면 바로 해결이 가능하지만, page router를 사용하므로 이 부분은 어떤식으로 해결할지 고민이 필요할거같습니다.

## 관련 링크

[페이지 라우터 레이아웃 공식문서](https://nextjs-ko.org/docs/pages/building-your-application/routing/pages-and-layouts)

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #89 )

## 테스트 결과 (스크린샷)

<img width="532" height="584" alt="image" src="https://github.com/user-attachments/assets/d2bd0dad-fc2a-4865-8c42-9e5b3030e8e9" />

