### PR TITLE
feat: input, checkout, radiogroup 컴포넌트 구현

### DIFF
--- a/components/common/ui/Checkbox/Checkbox.tsx
+++ b/components/common/ui/Checkbox/Checkbox.tsx
@@ -1,0 +1,73 @@
+import { useId } from 'react';
+import type { ReactNode, Dispatch, SetStateAction, InputHTMLAttributes } from 'react';
+import { cn } from '@/utils/cn';
+
+interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
+  checked?: boolean;
+  onCheckedChange?: Dispatch<SetStateAction<boolean>>;
+  children?: ReactNode;
+  className?: string;
+}
+
+function Checkbox({
+  checked = false,
+  onCheckedChange,
+  children,
+  className,
+  id,
+  disabled,
+  ...props
+}: CheckboxProps) {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+
+  return (
+    <label
+      htmlFor={inputId}
+      className={cn(
+        'flex items-center gap-2.5 cursor-pointer group select-none',
+        disabled && 'opacity-50 cursor-not-allowed',
+        className
+      )}
+    >
+      <input
+        type="checkbox"
+        id={inputId}
+        checked={checked}
+        disabled={disabled}
+        className="sr-only"
+        onChange={e => onCheckedChange?.(e.target.checked)}
+        {...props}
+      />
+
+      <div
+        className={cn(
+          'w-5 h-5 rounded border-2 flex items-center justify-center transition-all duration-200',
+          'group-active:scale-95', // 클릭 시 쫀득한 반응성
+          checked
+            ? 'bg-primary border-primary shadow-sm'
+            : 'bg-white border-gray-300 group-hover:border-gray-400'
+        )}
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="white"
+          strokeWidth="3.5"
+          className={cn(
+            'w-3.5 h-3.5 transition-transform duration-200 ease-in-out',
+            checked ? 'scale-100' : 'scale-0'
+          )}
+        >
+          <path d="M20 6L9 17L4 12" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </div>
+
+      {children && (
+        <span className="text-sm font-medium text-slate-700 leading-none">{children}</span>
+      )}
+    </label>
+  );
+}
+
+export { Checkbox };

--- a/components/common/ui/Checkbox/index.ts
+++ b/components/common/ui/Checkbox/index.ts
@@ -1,0 +1,1 @@
+export { Checkbox } from './Checkbox';

--- a/components/common/ui/Input.tsx
+++ b/components/common/ui/Input.tsx
@@ -1,14 +1,13 @@
-import { ComponentPropsWithRef, ReactNode, ChangeEvent } from 'react';
+import { ComponentPropsWithRef, ReactNode } from 'react';
 import { cn } from '@/utils/cn';
 import Image from 'next/image';
 import iconInputError from '@/assets/icon/icon-input-error.svg';
 
-interface InputProps extends Omit<ComponentPropsWithRef<'input'>, 'type' | 'onChange' | 'prefix'> {
+interface InputProps extends Omit<ComponentPropsWithRef<'input'>, 'type' | 'prefix'> {
   type?: 'text' | 'password';
   status?: 'default' | 'error';
   prefix?: ReactNode;
   suffix?: ReactNode;
-  onChange?: (value: string) => void;
 }
 
 const Input = ({
@@ -17,14 +16,9 @@ const Input = ({
   status = 'default',
   prefix,
   suffix,
-  onChange,
   ref,
   ...props
 }: InputProps) => {
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    onChange?.(e.target.value);
-  };
-
   const suffixContent =
     suffix ??
     (status === 'error' ? (
@@ -40,7 +34,6 @@ const Input = ({
       <input
         ref={ref}
         type={type}
-        onChange={handleChange}
         aria-invalid={status === 'error' ? 'true' : 'false'}
         className={cn(
           'w-full h-11 rounded border transition-colors outline-none text-sm',

--- a/components/common/ui/RadioGroup/RadioGroup.tsx
+++ b/components/common/ui/RadioGroup/RadioGroup.tsx
@@ -1,0 +1,92 @@
+import { createContext, useContext, useId } from 'react';
+import type { ReactNode, Dispatch, SetStateAction } from 'react';
+
+import { cn } from '@/utils/cn';
+
+interface RadioGroupContextValue {
+  value: string;
+  onValueChange: Dispatch<SetStateAction<string>>;
+  name: string;
+}
+
+interface RadioGroupProps {
+  value: string;
+  onValueChange: Dispatch<SetStateAction<string>>;
+  children: ReactNode;
+  className?: string;
+  name?: string;
+}
+
+interface RadioGroupItemProps {
+  value: string;
+  id?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+const RadioGroupContext = createContext<RadioGroupContextValue | null>(null);
+
+const useRadioGroup = () => {
+  const ctx = useContext(RadioGroupContext);
+  if (!ctx) {
+    throw new Error('RadioGroup 내부에서만 사용');
+  }
+  return ctx;
+};
+
+function RadioGroup({ value, onValueChange, children, className, name }: RadioGroupProps) {
+  const generatedName = useId();
+  const groupName = name ?? generatedName;
+  return (
+    <div className={cn('flex gap-2', className)} role="radiogroup">
+      <RadioGroupContext.Provider value={{ value, onValueChange, name: groupName }}>
+        {children}
+      </RadioGroupContext.Provider>
+    </div>
+  );
+}
+
+function RadioGroupItem({ value, id, children, className }: RadioGroupItemProps) {
+  const { value: currentValue, onValueChange, name } = useRadioGroup();
+  const isSelected = currentValue === value;
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+
+  return (
+    <label
+      htmlFor={inputId}
+      className={cn('flex items-center gap-3 cursor-pointer group select-none', className)}
+    >
+      <input
+        type="radio"
+        id={inputId}
+        name={name}
+        value={value}
+        className="sr-only"
+        checked={isSelected}
+        onChange={() => onValueChange(value)}
+      />
+
+      <div
+        className={cn(
+          'relative w-4 h-4 rounded border-2 transition-all duration-200 flex items-center justify-center',
+          'group-hover:border-primary/70',
+          isSelected ? 'border-primary bg-transparent' : 'border-gray-300 bg-white'
+        )}
+      >
+        <div
+          className={cn(
+            'w-2 h-2 rounded bg-primary transition-transform duration-200',
+            isSelected ? 'scale-100' : 'scale-0'
+          )}
+        />
+      </div>
+
+      {children && (
+        <span className="text-sm font-medium leading-none text-gray-700">{children}</span>
+      )}
+    </label>
+  );
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/components/common/ui/RadioGroup/index.ts
+++ b/components/common/ui/RadioGroup/index.ts
@@ -1,0 +1,1 @@
+export { RadioGroup, RadioGroupItem } from './RadioGroup';

--- a/lib/auth/cookie.ts
+++ b/lib/auth/cookie.ts
@@ -1,11 +1,18 @@
 export const getCookieOptions = (maxAge: number) => {
   const isProd = process.env.NODE_ENV === 'production';
-  return `Path=/; HttpOnly; SameSite=Lax; Max-Age=${maxAge}; ${isProd ? '; Secure' : ''}`;
+
+  const parts = ['Path=/', 'HttpOnly', 'SameSite=Lax', `Max-Age=${maxAge}`];
+
+  if (isProd) parts.push('Secure');
+
+  return parts.join('; ');
 };
 
 export const AUTH_COOKIES = {
-  accessToken: (token: string) => `accessToken=${token}; ${getCookieOptions(60 * 60 * 24 * 7)}`,
-  refreshToken: (token: string) => `refreshToken=${token}; ${getCookieOptions(60 * 60 * 24 * 7)}`,
-  clearAccessToken: () => `accessToken=; Path=/; Max-Age=0`,
-  clearRefreshToken: () => `refreshToken=; Path=/; Max-Age=0`,
+  accessToken: (token: string) =>
+    `accessToken=${encodeURIComponent(token)}; ${getCookieOptions(60 * 30)}`,
+  refreshToken: (token: string) =>
+    `refreshToken=${encodeURIComponent(token)}; ${getCookieOptions(60 * 60 * 24 * 7)}`,
+  clearAccessToken: () => `accessToken=; ${getCookieOptions(0)}`,
+  clearRefreshToken: () => `refreshToken=; ${getCookieOptions(0)}`,
 };

--- a/pages/api/auth/signin.ts
+++ b/pages/api/auth/signin.ts
@@ -27,11 +27,13 @@ export default async function handler(
     });
 
     if (!response.ok) {
-      if (response.status === 401 || response.status === 400) {
+      if (response.status === 401) {
         return res.status(401).json({ message: '이메일 또는 비밀번호가 일치하지 않습니다.' });
       }
 
-      return res.status(response.status).json({ message: '서버 오류가 발생했습니다.' });
+      const errorData = await response.json();
+
+      return res.status(response.status).json(errorData);
     }
 
     const data: AuthResponse = await response.json();


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- Input 리팩토링
  - 커스텀 동작하던 onChange 로직을 제거하고, 브라우저 표준 상태 (e.target...) 등 그대로 이용할 수 있도록 수정하였습니다.
- RadioGroup 컴포넌트
  - ContextAPI를 활용해서 Group 단위로 움직이도록 처리했습니다.
- Checkbox 컴포넌트
  - Checkbox는 한개의 단위로 움직이는 경우가 많아서 단일로 작업하였습니다.

## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.
(예: 이 로직을 훅으로 분리하는 게 맞는지 확신이 안 섭니다. / A방식과 B방식 중 성능 때문에 A를 택했는데 의견 궁금합니다.)

- RadioGroup 컴포넌트와, Checkbox 컴포넌트가 둘다 사각형으로 비슷하게 보입니다.

디자인과 동일하게 가기 위해서 네모로 처리했는데 적합할지 모르겠습니다.
내부의 모양을 다르게 해서 처리했으며, 스타일은 figma와 shadcn을 참고하였습니다.

- Checkbox 같은 경우에는 Group으로 묶지않고 단일로 관리하도록 설계했습니다.

Checkbox는 단일 Checkbox 인 경우도 있고, 그룹단위도 있지만 이 부분은 Group으로 묶을 필요는 없어보여서 단일로 선택했습니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #95 )

## 테스트 결과 (스크린샷)

<img width="1004" height="561" alt="image" src="https://github.com/user-attachments/assets/53a3c704-f45c-4ad0-b055-a8a761ce483b" />

