### PR TITLE
feat: 상세페이지 전체 ui작업

### DIFF
--- a/components/review/AromaList.tsx
+++ b/components/review/AromaList.tsx
@@ -8,11 +8,11 @@ interface AromaListProps {
 
 export default function AromaList({ aromas }: AromaListProps) {
   return (
-    <div className="flex gap-2 mb-2">
+    <div className="flex flex-wrap items-center gap-x-1 gap-y-2 mb-2">
       {aromas.map((a, i) => (
         <Fragment key={a}>
           <AromaBadge type={a} />
-          {i < aromas.length - 1 && <span>·</span>}
+          {i < aromas.length - 1 && <span className="inline-block px-1 text-gray-400">·</span>}
         </Fragment>
       ))}
     </div>

--- a/components/wine/detail/HeroSection.tsx
+++ b/components/wine/detail/HeroSection.tsx
@@ -1,0 +1,16 @@
+import Container from '@/components/common/layout/Container';
+import Gnb from '@/components/common/layout/Gnb';
+
+export default function HeroSection() {
+  return (
+    <div className="bg-gray-50 pt-px lg:rounded-b-[88px]">
+      <Gnb />
+
+      <Container>
+        <section className=" h-[400px] flex items-center justify-center">
+          <span className="text-gray-400">와인 상세 정보</span>
+        </section>
+      </Container>
+    </div>
+  );
+}

--- a/components/wine/detail/ReviewSection.tsx
+++ b/components/wine/detail/ReviewSection.tsx
@@ -9,13 +9,13 @@ export default function ReviewSection() {
   const { totalReviews, averageRating, distribution } = useReviewStats(mockListReviews);
 
   return (
-    <section className="w-full py-6 md:py-10 lg:py-20 px-0 border-b border-border">
+    <section className="w-full py-6 md:py-10 lg:py-20 px-0">
       <div className="flex flex-col-reverse lg:flex-row gap-16 items-start">
         <div className="flex-1 w-full">
           <div className="flex justify-between items-center mb-10">
             <div className="flex items-baseline gap-3.5">
               <h2 className="text-2xl font-bold text-foreground">리뷰 목록</h2>
-              <span className="text-base text-muted-foreground font-medium">
+              <span className="text-basic text-muted-foreground font-medium">
                 {totalReviews.toLocaleString()}개
               </span>
             </div>
@@ -34,7 +34,7 @@ export default function ReviewSection() {
         <div className="w-full lg:w-[350px]">
           <div className="flex flex-col gap-10">
             <ReviewStats rating={averageRating} distribution={distribution} />
-            <Button variant="primary" className="h-[60px] text-lg font-bold">
+            <Button variant="primary" className="text-lg font-bold">
               리뷰 남기기
             </Button>
           </div>

--- a/components/wine/detail/ReviewSection.tsx
+++ b/components/wine/detail/ReviewSection.tsx
@@ -1,31 +1,21 @@
 import Button from '@/components/common/ui/Button';
 import ReviewFeedCard from '@/components/reviewCard/ReviewFeedCard';
-import ReviewStats from '@/components/wine/detail/ReviewStates';
+import ReviewStats from '@/components/wine/detail/ReviewStats';
 import { mockListReviews } from '@/mock/review.list.mock';
+import { useReviewStats } from '@/hooks/useReviewStats';
 
 export default function ReviewSection() {
   const currentUserId = 10;
-  const totalReviews = mockListReviews.length;
-  const averageRating =
-    totalReviews > 0 ? mockListReviews.reduce((acc, cur) => acc + cur.rating, 0) / totalReviews : 0;
-  const distribution = [5, 4, 3, 2, 1].map(star => {
-    const count = mockListReviews.filter(r => r.rating === star).length;
-    const percentage = totalReviews > 0 ? (count / totalReviews) * 100 : 0;
-
-    return {
-      star,
-      ratio: `w-[${percentage}%]`,
-    };
-  });
+  const { totalReviews, averageRating, distribution } = useReviewStats(mockListReviews);
 
   return (
-    <section className="w-full py-6 md:py-10 lg:py-20 px-0">
+    <section className="w-full py-6 md:py-10 lg:py-20 px-0 border-b border-border">
       <div className="flex flex-col-reverse lg:flex-row gap-16 items-start">
         <div className="flex-1 w-full">
           <div className="flex justify-between items-center mb-10">
             <div className="flex items-baseline gap-3.5">
               <h2 className="text-2xl font-bold text-foreground">리뷰 목록</h2>
-              <span className="text-basic text-muted-foreground font-medium">
+              <span className="text-base text-muted-foreground font-medium">
                 {totalReviews.toLocaleString()}개
               </span>
             </div>
@@ -41,11 +31,10 @@ export default function ReviewSection() {
             ))}
           </div>
         </div>
-
         <div className="w-full lg:w-[350px]">
           <div className="flex flex-col gap-10">
             <ReviewStats rating={averageRating} distribution={distribution} />
-            <Button variant="primary" className="text-lg font-bold">
+            <Button variant="primary" className="h-[60px] text-lg font-bold">
               리뷰 남기기
             </Button>
           </div>

--- a/components/wine/detail/ReviewSection.tsx
+++ b/components/wine/detail/ReviewSection.tsx
@@ -1,0 +1,56 @@
+import Button from '@/components/common/ui/Button';
+import ReviewFeedCard from '@/components/reviewCard/ReviewFeedCard';
+import ReviewStats from '@/components/wine/detail/ReviewStates';
+import { mockListReviews } from '@/mock/review.list.mock';
+
+export default function ReviewSection() {
+  const currentUserId = 10;
+  const totalReviews = mockListReviews.length;
+  const averageRating =
+    totalReviews > 0 ? mockListReviews.reduce((acc, cur) => acc + cur.rating, 0) / totalReviews : 0;
+  const distribution = [5, 4, 3, 2, 1].map(star => {
+    const count = mockListReviews.filter(r => r.rating === star).length;
+    const percentage = totalReviews > 0 ? (count / totalReviews) * 100 : 0;
+
+    return {
+      star,
+      ratio: `w-[${percentage}%]`,
+    };
+  });
+
+  return (
+    <section className="w-full py-6 md:py-10 lg:py-20 px-0">
+      <div className="flex flex-col-reverse lg:flex-row gap-16 items-start">
+        <div className="flex-1 w-full">
+          <div className="flex justify-between items-center mb-10">
+            <div className="flex items-baseline gap-3.5">
+              <h2 className="text-2xl font-bold text-foreground">리뷰 목록</h2>
+              <span className="text-basic text-muted-foreground font-medium">
+                {totalReviews.toLocaleString()}개
+              </span>
+            </div>
+          </div>
+
+          <div className="">
+            {mockListReviews.map(review => (
+              <ReviewFeedCard
+                key={review.id}
+                review={review}
+                isOwner={review.user.id === currentUserId}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="w-full lg:w-[350px]">
+          <div className="flex flex-col gap-10">
+            <ReviewStats rating={averageRating} distribution={distribution} />
+            <Button variant="primary" className="text-lg font-bold">
+              리뷰 남기기
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/wine/detail/ReviewStates.tsx
+++ b/components/wine/detail/ReviewStates.tsx
@@ -1,0 +1,38 @@
+import { cn } from '@/utils/cn';
+import ReviewRating from '@/components/review/ReviewRating';
+
+interface ReviewStatsProps {
+  rating: number;
+  distribution: { star: number; ratio: string }[];
+}
+
+export default function ReviewStats({ rating, distribution }: ReviewStatsProps) {
+  return (
+    <div className="flex flex-col md:flex-row lg:flex-col gap-8 md:items-center lg:items-start">
+      <div className="flex items-center gap-4 md:flex-1 lg:flex-none">
+        <div className="text-2xl origin-left flex gap-1">
+          <ReviewRating rating={Math.round(rating)} />
+        </div>
+        <div className="flex items-baseline gap-1">
+          <span className="text-2xl text-foreground font-bold tracking-tighter">
+            {rating.toFixed(1)}
+          </span>
+          <span className="text-2xl text-muted-foreground font-bold">/ 5.0</span>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2 w-full md:flex-1 lg:w-full">
+        {distribution.map(item => (
+          <div key={item.star} className="flex items-center gap-4">
+            <span className="text-basic font-bold w-6 shrink-0 text-muted-foreground">
+              {item.star}점
+            </span>
+            <div className="flex-1 h-1.5 bg-secondary rounded-full overflow-hidden">
+              <div className={cn('h-full bg-foreground transition-all duration-500', item.ratio)} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/wine/detail/ReviewStats.tsx
+++ b/components/wine/detail/ReviewStats.tsx
@@ -1,9 +1,9 @@
-import { cn } from '@/utils/cn';
 import ReviewRating from '@/components/review/ReviewRating';
+import { ReviewStatItem } from '@/utils/reviewStats';
 
 interface ReviewStatsProps {
   rating: number;
-  distribution: { star: number; ratio: string }[];
+  distribution: ReviewStatItem[];
 }
 
 export default function ReviewStats({ rating, distribution }: ReviewStatsProps) {
@@ -28,7 +28,10 @@ export default function ReviewStats({ rating, distribution }: ReviewStatsProps) 
               {item.star}점
             </span>
             <div className="flex-1 h-1.5 bg-secondary rounded-full overflow-hidden">
-              <div className={cn('h-full bg-foreground transition-all duration-500', item.ratio)} />
+              <div
+                className="h-full bg-foreground transition-all duration-500"
+                style={{ width: `${item.ratio}%` }}
+              />
             </div>
           </div>
         ))}

--- a/components/wine/detail/WineDetailLayout.tsx
+++ b/components/wine/detail/WineDetailLayout.tsx
@@ -1,0 +1,12 @@
+import Container from '@/components/common/layout/Container';
+import WineProfile from '@/components/wine/detail/WineProfile';
+import ReviewSection from '@/components/wine/detail/ReviewSection';
+
+export default function WineDetailLayout() {
+  return (
+    <Container>
+      <WineProfile />
+      <ReviewSection />
+    </Container>
+  );
+}

--- a/components/wine/detail/WineProfile.tsx
+++ b/components/wine/detail/WineProfile.tsx
@@ -1,0 +1,20 @@
+import { cn } from '@/utils/cn';
+
+export default function WineProfile() {
+  return (
+    <section className="flex flex-col lg:flex-row gap-y-12 lg:gap-y-0 lg:gap-x-20 py-6 md:py-10 lg:py-20 border-b border-border">
+      <div className="flex-1 space-y-8">
+        <div className="flex flex-col lg:flex-row lg:justify-between lg:items-end gap-0 lg:gap-0 mb-6">
+          <h3 className="text-2xl font-bold">어떤 맛이 나나요?</h3>
+          <span className="text-sm text-muted-foreground">(417명 참여)</span>
+        </div>
+      </div>
+      <div className="flex-1 space-y-8">
+        <div className="flex flex-col lg:flex-row lg:justify-between lg:items-end gap-0 lg:gap-0 mb-6">
+          <h3 className="text-2xl font-bold">어떤 향이 나나요?</h3>
+          <span className="text-sm text-muted-foreground">(417명 참여)</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/wine/detail/WineProfile.tsx
+++ b/components/wine/detail/WineProfile.tsx
@@ -1,5 +1,3 @@
-import { cn } from '@/utils/cn';
-
 export default function WineProfile() {
   return (
     <section className="flex flex-col lg:flex-row gap-y-12 lg:gap-y-0 lg:gap-x-20 py-6 md:py-10 lg:py-20 border-b border-border">

--- a/hooks/useReviewStats.ts
+++ b/hooks/useReviewStats.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
-import { Review, calculateAverage, calculateDistribution } from '@/utils/reviewStats';
+import { Review } from '@/types/domain/review';
+import { calculateAverage, calculateDistribution } from '@/utils/reviewStats';
 
 export const useReviewStats = (reviews: Review[] = []) => {
   return useMemo(() => {

--- a/hooks/useReviewStats.ts
+++ b/hooks/useReviewStats.ts
@@ -1,0 +1,12 @@
+import { useMemo } from 'react';
+import { Review, calculateAverage, calculateDistribution } from '@/utils/reviewStats';
+
+export const useReviewStats = (reviews: Review[] = []) => {
+  return useMemo(() => {
+    return {
+      totalReviews: reviews.length,
+      averageRating: calculateAverage(reviews),
+      distribution: calculateDistribution(reviews),
+    };
+  }, [reviews]);
+};

--- a/pages/wines/[wineid].tsx
+++ b/pages/wines/[wineid].tsx
@@ -1,7 +1,7 @@
 import HeroSection from '@/components/wine/detail/HeroSection';
 import WineDetailLayout from '@/components/wine/detail/WineDetailLayout';
 
-export default function WineListPage() {
+export default function WineDetailPage() {
   return (
     <main>
       <HeroSection />

--- a/pages/wines/[wineid].tsx
+++ b/pages/wines/[wineid].tsx
@@ -1,0 +1,11 @@
+import HeroSection from '@/components/wine/detail/HeroSection';
+import WineDetailLayout from '@/components/wine/detail/WineDetailLayout';
+
+export default function WineListPage() {
+  return (
+    <main>
+      <HeroSection />
+      <WineDetailLayout />
+    </main>
+  );
+}

--- a/utils/reviewStats.ts
+++ b/utils/reviewStats.ts
@@ -1,6 +1,5 @@
-export interface Review {
-  rating: number;
-}
+import { Review } from '@/types/domain/review';
+
 export interface ReviewStatItem {
   star: number;
   ratio: number;
@@ -8,13 +7,12 @@ export interface ReviewStatItem {
 
 export const calculateAverage = (reviews: Review[]): number => {
   if (reviews.length === 0) return 0;
-  const totalRating = reviews.reduce((acc, cur) => acc + cur.rating, 0);
-  return totalRating / reviews.length;
+  const total = reviews.reduce((acc, curr) => acc + curr.rating, 0);
+  return total / reviews.length;
 };
 
 export const calculateDistribution = (reviews: Review[]): ReviewStatItem[] => {
   const total = reviews.length;
-
   return [5, 4, 3, 2, 1].map(star => {
     const count = reviews.filter(r => r.rating === star).length;
     return {

--- a/utils/reviewStats.ts
+++ b/utils/reviewStats.ts
@@ -1,0 +1,25 @@
+export interface Review {
+  rating: number;
+}
+export interface ReviewStatItem {
+  star: number;
+  ratio: number;
+}
+
+export const calculateAverage = (reviews: Review[]): number => {
+  if (reviews.length === 0) return 0;
+  const totalRating = reviews.reduce((acc, cur) => acc + cur.rating, 0);
+  return totalRating / reviews.length;
+};
+
+export const calculateDistribution = (reviews: Review[]): ReviewStatItem[] => {
+  const total = reviews.length;
+
+  return [5, 4, 3, 2, 1].map(star => {
+    const count = reviews.filter(r => r.rating === star).length;
+    return {
+      star,
+      ratio: total > 0 ? (count / total) * 100 : 0,
+    };
+  });
+};


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

상세페이지 작업했습니다. 

## 같이 고민해 주세요 (리뷰 포인트)
드롭다운, 상단, 맛 그래프, 향 부분 추가 해야함, 추가하면서 디자인도 같이 고도화하면 될듯합니다. 

수정 사항

- utils/reviewStats.ts , hooks/useReviewStats.ts 생성 
- Tailwind는 동적 클래스 생성을 인식하지 못하는 이슈로 막대 그래프의 너비는 인라인 스타일로 처리
- 향  뱃지 모바일  대응을 위해 AromaList 컴포넌트 수정 

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #121 )

## 테스트 결과 (스크린샷)
pc 상
<img width="1431" height="777" alt="스크린샷 2026-02-17 오후 4 18 52" src="https://github.com/user-attachments/assets/1460cacd-9901-4a76-825b-da2285933128" />
pc 하
<img width="1467" height="870" alt="스크린샷 2026-02-17 오후 4 19 01" src="https://github.com/user-attachments/assets/d7ba01e5-9f40-48cd-bccc-e0ba437cb184" />
태블릿 상 
<img width="639" height="767" alt="스크린샷 2026-02-17 오후 4 19 26" src="https://github.com/user-attachments/assets/989315d8-59a0-46d6-ac60-2cdd6cd3cdcc" />
태블릿 하
<img width="651" height="771" alt="스크린샷 2026-02-17 오후 4 19 33" src="https://github.com/user-attachments/assets/0df9e8eb-be18-4ca9-9ff6-470ea5b0ab64" />
모바일 상
<img width="461" height="715" alt="스크린샷 2026-02-17 오후 4 19 51" src="https://github.com/user-attachments/assets/071c6192-925e-41f1-b39d-7618ec4a991f" />
모바일 하
<img width="404" height="758" alt="스크린샷 2026-02-18 오후 10 24 41" src="https://github.com/user-attachments/assets/1cc97c29-84dc-4af4-aae0-40e9fc9ecabe" />





작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)
