### PR TITLE
feat: form validation hooks

### DIFF
--- a/hooks/useForm/index.ts
+++ b/hooks/useForm/index.ts
@@ -1,0 +1,2 @@
+export { useForm } from './useForm';
+export type { useFormProps, RegisterOptions, FormMode, Field } from './types';

--- a/hooks/useForm/types.ts
+++ b/hooks/useForm/types.ts
@@ -1,0 +1,29 @@
+export type FormMode = 'onSubmit' | 'onBlur' | 'onTouched';
+
+export interface ValidationRule<T> {
+  value: T;
+  message: string;
+}
+
+export interface RegisterOptions<
+  TFieldValues extends Record<string, unknown> = Record<string, unknown>,
+  TfieldName extends keyof TFieldValues = keyof TFieldValues,
+> {
+  required?: string | boolean;
+  minLength?: ValidationRule<number>;
+  maxLength?: ValidationRule<number>;
+  pattern?: ValidationRule<RegExp>;
+  validate?: (value: TFieldValues[TfieldName], values: TFieldValues) => string | undefined;
+
+  deps?: (keyof TFieldValues)[];
+}
+
+export interface Field<TFieldValues extends Record<string, unknown> = Record<string, unknown>> {
+  elements: (HTMLInputElement | HTMLTextAreaElement | null)[];
+  rules: RegisterOptions<TFieldValues>;
+  isTouched: boolean;
+}
+
+export interface useFormProps {
+  mode?: FormMode;
+}

--- a/hooks/useForm/useForm.ts
+++ b/hooks/useForm/useForm.ts
@@ -1,0 +1,177 @@
+import { useRef, useState, useCallback, useEffect } from 'react';
+import type { FormEvent } from 'react';
+import type { useFormProps, Field, RegisterOptions } from './types';
+import { getErrorMessage } from './utils';
+
+function useForm<TFieldValues extends Record<string, unknown> = Record<string, unknown>>({
+  mode = 'onSubmit',
+}: useFormProps = {}) {
+  const [errors, setErrors] = useState<Partial<Record<keyof TFieldValues, string>>>({});
+  const errorsRef = useRef(errors);
+  const fieldsRef = useRef<Partial<Record<keyof TFieldValues, Field<TFieldValues>>>>({});
+
+  useEffect(() => {
+    errorsRef.current = errors;
+  }, [errors]);
+
+  const getValues = useCallback((): TFieldValues => {
+    const values = {} as TFieldValues;
+
+    Object.entries(fieldsRef.current).forEach(([key, field]) => {
+      const name = key as keyof TFieldValues;
+      const validElements = field!.elements.filter(
+        (el): el is HTMLInputElement | HTMLTextAreaElement => el !== null
+      );
+
+      if (validElements.length === 0) return;
+
+      const firstEl = validElements[0];
+
+      if (firstEl instanceof HTMLInputElement) {
+        const { type, multiple } = firstEl;
+
+        if (type === 'checkbox') {
+          if (validElements.length > 1) {
+            values[name] = validElements
+              .filter(el => (el as HTMLInputElement).checked)
+              .map(el => el.value) as TFieldValues[keyof TFieldValues];
+          } else {
+            values[name] = firstEl.checked as TFieldValues[keyof TFieldValues];
+          }
+        } else if (type === 'radio') {
+          const checkedEl = validElements.find(el => (el as HTMLInputElement).checked);
+          values[name] = checkedEl?.value as TFieldValues[keyof TFieldValues];
+        } else if (type === 'file') {
+          if (multiple) {
+            values[name] = Array.from(firstEl.files || []) as TFieldValues[keyof TFieldValues];
+          } else {
+            values[name] = (firstEl.files?.[0] || null) as TFieldValues[keyof TFieldValues];
+          }
+        } else {
+          values[name] = firstEl.value as TFieldValues[keyof TFieldValues];
+        }
+      } else {
+        values[name] = firstEl.value as TFieldValues[keyof TFieldValues];
+      }
+    });
+
+    return values;
+  }, []);
+
+  const validateField = useCallback(
+    (name: keyof TFieldValues, isTriggered = false) => {
+      function run(targetName: keyof TFieldValues, triggered: boolean) {
+        const field = fieldsRef.current[targetName];
+        if (!field) return;
+
+        const values = getValues();
+        const errorMessage = getErrorMessage(field.rules, values[targetName], values);
+
+        setErrors(prev => {
+          if (prev[targetName] === errorMessage) return prev;
+          const next = { ...prev };
+          if (errorMessage) next[targetName] = errorMessage;
+          else delete next[targetName];
+          return next;
+        });
+
+        if (!triggered && field.rules.deps) {
+          field.rules.deps.forEach(depName => run(depName, true));
+        }
+      }
+      run(name, isTriggered);
+    },
+    [getValues]
+  );
+
+  const register = useCallback(
+    <TFieldName extends keyof TFieldValues>(
+      name: TFieldName,
+      rules: RegisterOptions<TFieldValues, TFieldName> = {}
+    ) => {
+      if (!fieldsRef.current[name]) {
+        fieldsRef.current[name] = {
+          elements: [],
+          rules: rules as RegisterOptions<TFieldValues>,
+          isTouched: false,
+        };
+      } else {
+        fieldsRef.current[name]!.rules = rules as RegisterOptions<TFieldValues>;
+      }
+
+      return {
+        name,
+        ref: (element: HTMLInputElement | HTMLTextAreaElement | null) => {
+          if (!element) {
+            if (fieldsRef.current[name]) {
+              fieldsRef.current[name]!.elements = fieldsRef.current[name]!.elements.filter(
+                el => el !== null && el !== element
+              );
+            }
+            return;
+          }
+          if (!fieldsRef.current[name]!.elements.includes(element)) {
+            fieldsRef.current[name]!.elements.push(element);
+          }
+        },
+        onBlur: () => {
+          fieldsRef.current[name]!.isTouched = true;
+          if (mode === 'onBlur' || mode === 'onTouched') {
+            validateField(name);
+          }
+        },
+        onChange: () => {
+          if (
+            errorsRef.current[name] ||
+            (mode === 'onTouched' && fieldsRef.current[name]!.isTouched)
+          ) {
+            validateField(name);
+          }
+        },
+      };
+    },
+    [validateField, mode]
+  );
+
+  const handleSubmit = useCallback(
+    (
+      onValid: (data: TFieldValues) => void | Promise<void>,
+      onInvalid?: (errors: Partial<Record<keyof TFieldValues, string>>) => void | Promise<void>
+    ) =>
+      async (e?: FormEvent) => {
+        if (e) e.preventDefault();
+
+        const values = getValues();
+        const nextErrors: Partial<Record<keyof TFieldValues, string>> = {};
+        let isValid = true;
+
+        Object.entries(fieldsRef.current).forEach(([key, field]) => {
+          const name = key as keyof TFieldValues;
+          const typedField = field as Field<TFieldValues>;
+          const errorMessage = getErrorMessage(typedField.rules, values[name], values);
+          if (errorMessage) {
+            nextErrors[name] = errorMessage;
+            isValid = false;
+          }
+        });
+
+        setErrors(nextErrors);
+
+        if (isValid) {
+          await onValid(values);
+        } else {
+          await onInvalid?.(nextErrors);
+        }
+      },
+    [getValues]
+  );
+
+  return {
+    register,
+    getValues,
+    handleSubmit,
+    errors,
+  };
+}
+
+export { useForm };

--- a/hooks/useForm/utils.ts
+++ b/hooks/useForm/utils.ts
@@ -1,0 +1,41 @@
+import type { RegisterOptions } from './types';
+
+export const getErrorMessage = <
+  TFieldValues extends Record<string, unknown>,
+  TFieldName extends keyof TFieldValues,
+>(
+  rules: RegisterOptions<TFieldValues, TFieldName>,
+  value: unknown,
+  allValues: TFieldValues
+): string | undefined => {
+  if (rules.required) {
+    const isEmpty =
+      value == null ||
+      (typeof value === 'string' && value.trim().length === 0) ||
+      (Array.isArray(value) && value.length === 0) ||
+      value === false;
+
+    if (isEmpty) {
+      return typeof rules.required === 'string' ? rules.required : '필수 입력 항목입니다.';
+    }
+  }
+
+  if (rules.minLength && typeof value === 'string' && value.length < rules.minLength.value) {
+    return rules.minLength.message || `${rules.minLength.value}자 이상 입력해주세요.`;
+  }
+
+  if (rules.maxLength && typeof value === 'string' && value.length > rules.maxLength.value) {
+    return rules.maxLength.message || `${rules.maxLength.value}자 이하 입력해주세요.`;
+  }
+
+  if (rules.pattern && typeof value === 'string' && !rules.pattern.value.test(value)) {
+    return rules.pattern.message || '형식이 올바르지 않습니다.';
+  }
+
+  if (rules.validate) {
+    const result = rules.validate(value as TFieldValues[TFieldName], allValues);
+    if (typeof result === 'string') return result;
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- 외부라이브러리에 의존하지않고, 비제어 컴포넌트 기반의 폼 상태관리 useForm hook을 구현하였습니다.
  - 단순히 값을 입력받고 검증하는 부분을 넘어, 사용자가 타이핑할때마다 불필요한 리렌더링이 발생하는 현상을 차단하는 성능 최적화에 초점을 맞췄습니다.
 
- 비제어 기반 렌더링 최적화를 반영했습니다.
  - 사용자의 입력값을 state로 관리하는게 아닌 ref 를 이용하여 DOM 요소를 직접 조회하는 방향으로 진행하였습니다.

- 다양한 input type 지원
  - 사용하는 input 위주로 지원하도록 처리하였습니다.
  - text, password, radio, checkbox, file 까지만 지원하며, select는 디자인에 없어서 반영하지않았습니다. 

- UX를 고려한 3가지 검증 모드로 제한하였습니다.
  - onSubmit, onBlur, onTouched
    - onSubmit 은 submit이 눌린 시점에 검증을 하기 시작합니다.
    - onBlur는 blur 이벤트가 발생했을때 검증하기 시작합니다.
    - onTouched는 blur 이벤트가 1회 이상 발생하였을 경우 change 이벤트가 발생할때마다 다시 검증하도록 하였습니다.

- 교차 검증 (deps)
  - 지금은 비밀번호, 비밀번호 확인만 서로 의존성이 있지만 확장성을 고려하여 작업하였습니다. 

## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.
(예: 이 로직을 훅으로 분리하는 게 맞는지 확신이 안 섭니다. / A방식과 B방식 중 성능 때문에 A를 택했는데 의견 궁금합니다.)

### 불필요한 리렌더링을 잡기 위한 null 대신 undefined 를 사용하였습니다.

에러가 없는 상태에서 타이핑 할때마다 다시 리렌더링이 발생하는 이슈가 있었습니다. 확인해보니 errors 객체에 값이 없으면 undefined 를 반환하고있었고, errorMsg 는 초기값이 null 로 시작했습니다.

초기 수정은 일치 연산자에서 동등 연산자로 변경하여 해결하였으나 더 명시적으로 undefined 를 초기값으로 지정하고, 일치 연산자로 비교하도록 수정하였습니다.

이 렌더링 방어 로직이 상태 관리 측면에서 명시적이고 깔끔한지 의견이 궁금합니다!

### deps 연쇄 검증 시 무한 루프 및 클로저 방어 로직

deps 에 등록된 필드를 재귀적으로 검증할 때 무한 루프를 막기 위해 내부 함수를 호이스팅하여 사용했습니다. 

초기에는 함수 표현식을 이용했을때 검증을 제대로 안하는 문제가 있었습니다. 이 부분을 해결하기 위하여 함수 선언식을 이용하여 호이스팅으로 위로 끌어올려서 해결했습니다.

또한 errors 의 상태를 읽기 위해 의존성 배열에 errros 를 넣었으나 errors를 넣으면 errors 의 값이 변경될때마다 함수가 계속 재생성되는 문제가 있어 의존성을 제거하고 setErrores 내부에서 상태 비교를 할 수 있도록 변경했습니다.

이 부분에서 로직의 가독성 측면에서 괜찮은지 리뷰 부탁드립니다.

### 재검증 트리거 규칙과 UX 고민

현재 코드를 보면, 사용자가 mode 에 onBlur, onSubmit 등 선택했더라도 해당 필드에 에러가 노출된 상태라면 지정한 모드를 무시하고 onChange 마다 검증을 실행하고있습니다. 

사실상 mode가 의미가 없는 상황입니다. 
RHF의 경우 reValidateMode 라는 별도 옵션을 두고, 분리하였는데 저희도 설정의 일관성을 위해 옵션을 분리하는게 좋을지 아니면 사실상 onTouched 를 기본값으로 강제하는게 좋을지 의견 부탁드립니다.

### 외부 의존성을 줄이고자 했지만 RHF를 창조

처음 목표는 외부 라이브러리 없이 직접 만들어보자가 목적이였지만 사실상 RHF의 내부를 뜯어보고 분석하여 모방하였습니다.

실무적인 부분에서 결국 RHF랑 비슷하게 동작할거라면 굳이 직접 만든 경량화된 hook을 고도화하는것보다 RHF를 도입하는게 더 좋다고 생각이 들었습니다.

물론 이 과정에서 성능 이슈, 엣지 케이스들을 하나씩 해결해가고 내부 동작 원리를 깊게 이해하는데는 큰 도움이되었습니다.

### typescript 

작업하면서 RHF를 모방하였습니다.
이 과정에서 typescript는 AI의 도움을 적극적으로 받았습니다.

작업은 먼저 별도 react 환경에서 진행하고, type 정의는 AI의 도움을 많이 받았습니다.
보통 type은 어떤식으로 작업하고, 어떤식으로 학습하고게신지 궁금합니다.. typescript는 알다가도 전혀 모를거같습니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #123 )

## 테스트 결과 (스크린샷)

<img width="503" height="609" alt="image" src="https://github.com/user-attachments/assets/b04ba82c-a0e7-4249-bc53-6f17cbf69470" />

