### PR TITLE
feat: infiniteScroll hook 추가

### DIFF
--- a/hooks/useInfiniteScroll.ts
+++ b/hooks/useInfiniteScroll.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+
+interface UseInfiniteScrollOptions {
+  onIntersect: () => void | Promise<void>;
+  hasNextPage?: boolean;
+  loading?: boolean;
+  root?: Element | null;
+  rootMargin?: string;
+  threshold?: number;
+}
+
+export default function useInfiniteScroll<T extends Element = HTMLElement>({
+  onIntersect,
+  hasNextPage = true,
+  loading = false,
+  root = null,
+  rootMargin = '200px',
+  threshold = 0,
+}: UseInfiniteScrollOptions) {
+  const targetRef = useRef<T | null>(null);
+  const callbackRef = useRef(onIntersect);
+  const isFetchingRef = useRef(false);
+
+  const lastTriggerRef = useRef(0);
+  const TRIGGER_DELAY = 200;
+
+  useEffect(() => {
+    callbackRef.current = onIntersect;
+  }, [onIntersect]);
+
+  useEffect(() => {
+    const target = targetRef.current;
+    if (!target) return;
+    if (!hasNextPage) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) return;
+        if (isFetchingRef.current) return;
+
+        const now = Date.now();
+        if (now - lastTriggerRef.current < TRIGGER_DELAY) return;
+        lastTriggerRef.current = now;
+
+        isFetchingRef.current = true;
+        callbackRef.current();
+      },
+      { root, rootMargin, threshold }
+    );
+
+    observer.observe(target);
+
+    return () => observer.disconnect();
+  }, [hasNextPage, root, rootMargin, threshold]);
+
+  useEffect(() => {
+    if (!loading) isFetchingRef.current = false;
+  }, [loading]);
+
+  return targetRef;
+}


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- infiniteScroll hook 추가

## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.
(예: 이 로직을 훅으로 분리하는 게 맞는지 확신이 안 섭니다. / A방식과 B방식 중 성능 때문에 A를 택했는데 의견 궁금합니다.)

- infinityScroll 기능을 하는 infiniteScroll hook을 추가했습니다.
- 사용 방법은 훅을 호출해 ref를 받고, 스크롤 하다가 화면에 들어오면 트리거가 될 요소에 해당 ref를 연결, viewport에 요소가 보이면 onIntersect 콜백이 실행됩니다.
- 로딩 시 어떤 화면을 보여주면 좋을지에 대해서는 조금 더 고민이 필요합니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
Closes #133 

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)
