### PR TITLE
feat: auth cookie refresh 기능 추가

### DIFF
--- a/lib/auth/cookie.ts
+++ b/lib/auth/cookie.ts
@@ -1,3 +1,8 @@
+import type { NextApiResponse } from 'next';
+import type { ServerResponse } from 'http';
+
+export type HeaderHandleable = Pick<NextApiResponse | ServerResponse, 'setHeader' | 'getHeader'>;
+
 export const getCookieOptions = (maxAge: number) => {
   const isProd = process.env.NODE_ENV === 'production';
 
@@ -38,4 +43,12 @@ export const parseCookie = (cookieHeader?: string) => {
   });
 
   return output;
+};
+
+export const mergeSetCookie = (res: HeaderHandleable, newValue: string | string[]) => {
+  const prev = res.getHeader('Set-Cookie');
+  const prevArray = prev ? (Array.isArray(prev) ? prev.map(String) : [String(prev)]) : [];
+  const nextArray = Array.isArray(newValue) ? newValue : [newValue];
+
+  res.setHeader('Set-Cookie', [...prevArray, ...nextArray]);
 };

--- a/lib/auth/cookie.ts
+++ b/lib/auth/cookie.ts
@@ -15,4 +15,27 @@ export const AUTH_COOKIES = {
     `refreshToken=${encodeURIComponent(token)}; ${getCookieOptions(60 * 60 * 24 * 7)}`,
   clearAccessToken: () => `accessToken=; ${getCookieOptions(0)}`,
   clearRefreshToken: () => `refreshToken=; ${getCookieOptions(0)}`,
+
+  setAuth: (accessToken: string, refreshToken: string) => [
+    `accessToken=${encodeURIComponent(accessToken)}; ${getCookieOptions(60 * 30)}`,
+    `refreshToken=${encodeURIComponent(refreshToken)}; ${getCookieOptions(60 * 60 * 24 * 7)}`,
+  ],
+
+  clearAuth: () => [
+    `accessToken=; ${getCookieOptions(0)}`,
+    `refreshToken=; ${getCookieOptions(0)}`,
+  ],
+};
+
+export const parseCookie = (cookieHeader?: string) => {
+  const output: Record<string, string> = {};
+  if (!cookieHeader) return output;
+
+  cookieHeader.split(';').forEach(part => {
+    const [key, ...value] = part.trim().split('=');
+    if (!key) return;
+    output[key] = decodeURIComponent(value.join('=') ?? '');
+  });
+
+  return output;
 };

--- a/lib/auth/refresh.ts
+++ b/lib/auth/refresh.ts
@@ -1,0 +1,38 @@
+const BASE_URL = process.env.API_URL;
+
+type RefreshTokenResponse = {
+  accessToken?: unknown;
+};
+
+export const refreshAccessToken = async (refreshToken: string): Promise<string | null> => {
+  try {
+    const res = await fetch(`${BASE_URL}/auth/refresh-token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ refreshToken }),
+    });
+
+    if (!res.ok) {
+      console.error('리프래시 토큰 업데이트 중 오류 발생:', res);
+      return null;
+    }
+
+    let data: RefreshTokenResponse | null = null;
+
+    try {
+      data = (await res.json()) as RefreshTokenResponse;
+    } catch {
+      console.error('리프래시 토큰 업데이트 중 오류 발생:', res);
+      return null;
+    }
+
+    const accessToken = data?.accessToken;
+
+    return typeof accessToken === 'string' && accessToken.length > 0 ? accessToken : null;
+  } catch (error) {
+    console.error('리프래시 토큰 업데이트 중 오류 발생:', error);
+    return null;
+  }
+};

--- a/lib/auth/refreshAuthSession.ts
+++ b/lib/auth/refreshAuthSession.ts
@@ -1,22 +1,9 @@
-import type { NextApiResponse } from 'next';
-import type { ServerResponse } from 'http';
-
-import { AUTH_COOKIES } from './cookie';
+import { AUTH_COOKIES, mergeSetCookie, HeaderHandleable } from './cookie';
 import { refreshAccessToken } from './refresh';
-
-type HeaderHandleable = Pick<NextApiResponse | ServerResponse, 'setHeader' | 'getHeader'>;
 
 type RefreshAuthContext = {
   refreshToken: string | null | undefined;
   res: HeaderHandleable;
-};
-
-const mergeSetCookie = (res: HeaderHandleable, newValue: string | string[]) => {
-  const prev = res.getHeader('Set-Cookie');
-  const prevArray = prev ? (Array.isArray(prev) ? prev.map(String) : [String(prev)]) : [];
-  const nextArray = Array.isArray(newValue) ? newValue : [newValue];
-
-  res.setHeader('Set-Cookie', [...prevArray, ...nextArray]);
 };
 
 export const refreshAuthSession = async ({

--- a/lib/auth/refreshAuthSession.ts
+++ b/lib/auth/refreshAuthSession.ts
@@ -1,0 +1,40 @@
+import type { NextApiResponse } from 'next';
+import type { ServerResponse } from 'http';
+
+import { AUTH_COOKIES } from './cookie';
+import { refreshAccessToken } from './refresh';
+
+type HeaderHandleable = Pick<NextApiResponse | ServerResponse, 'setHeader' | 'getHeader'>;
+
+type RefreshAuthContext = {
+  refreshToken: string | null | undefined;
+  res: HeaderHandleable;
+};
+
+const mergeSetCookie = (res: HeaderHandleable, newValue: string | string[]) => {
+  const prev = res.getHeader('Set-Cookie');
+  const prevArray = prev ? (Array.isArray(prev) ? prev.map(String) : [String(prev)]) : [];
+  const nextArray = Array.isArray(newValue) ? newValue : [newValue];
+
+  res.setHeader('Set-Cookie', [...prevArray, ...nextArray]);
+};
+
+export const refreshAuthSession = async ({
+  refreshToken,
+  res,
+}: RefreshAuthContext): Promise<string | null> => {
+  if (!refreshToken) {
+    mergeSetCookie(res, AUTH_COOKIES.clearAuth());
+    return null;
+  }
+
+  const newAccessToken = await refreshAccessToken(refreshToken);
+
+  if (!newAccessToken) {
+    mergeSetCookie(res, AUTH_COOKIES.clearAuth());
+    return null;
+  }
+
+  mergeSetCookie(res, AUTH_COOKIES.accessToken(newAccessToken));
+  return newAccessToken;
+};


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- 인증 토큰 갱신 자동화 로직 구현
- 안전한 쿠키 병합 유틸리티 도입
- 공통 쿠키 관리 객체 추가

## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.
(예: 이 로직을 훅으로 분리하는 게 맞는지 확신이 안 섭니다. / A방식과 B방식 중 성능 때문에 A를 택했는데 의견 궁금합니다.)

- 쿠키 병합 유틸리티를 추가하면서 res.setHeader 를 직접 호출할 경우 리프레시 토큰을 발급받으면서 액세스토큰만 업데이트했는데 리프레시 토큰이 사라지는 문제가 있었습니다.
  - 기존 헤더를 배열로 받아 병합하는 방식으로 처리하였습니다.

- 관심사 분리
  - 토큰 갱신 로직 2곳으로 분리하여 관리하였으며, 순수 쿠키 조작만을 위한 cookie.ts 로 분리하였습니다.
  - 몇줄안되는 부분이라 통합할지 고민입니다.
  - 지금은 유효한 리프레시 토큰으로 액세스 토큰을 다시 발급하고 쿠키에 반영하는 부분까지만 작업되어있습니다.
    - 여기서 쿠키 발급 후 다시 요청을 보내는 로직으로 확장할지, 아니면 지금 상태를 유지하고 사용자가 직접 다시 보내도록 설계할지 고민중입니다.
    - 장점 : 단일 책임 원칙, 높은 재사용성, 테스트 용이성
    - 단점 : 실수 가능성 (사용하면서 refreshAuthSession만 호출 후 실패한 원래 요청을 다시 날려야해서 실수할 수 있음)

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #137 )

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)
