### PR TITLE
feat: listpage 필터 csr 처리 및 url query 연동 작업

### DIFF
--- a/components/common/ui/Dialog/Dialog.tsx
+++ b/components/common/ui/Dialog/Dialog.tsx
@@ -138,4 +138,5 @@ export {
   DialogTitle,
   DialogTrigger,
   useDialogState,
+  useDialog,
 };

--- a/components/filter/FilterModal.tsx
+++ b/components/filter/FilterModal.tsx
@@ -1,7 +1,8 @@
 import { ComponentProps } from 'react';
 import FilterContent from './FilterContent';
-import { Dialog, DialogContent, DialogTrigger } from '../common/ui/Dialog';
+import { Dialog, DialogClose, DialogContent, DialogTrigger } from '../common/ui/Dialog';
 import Button from '../common/ui/Button';
+import { useDialog } from '../common/ui/Dialog/Dialog';
 import Icon from '../common/ui/Icon';
 
 type FilterContentProps = ComponentProps<typeof FilterContent>;
@@ -11,24 +12,32 @@ interface FilterModalProps extends Omit<FilterContentProps, 'actions'> {
   onReset: () => void;
 }
 
+function TriggerBtn() {
+  const { setOpen } = useDialog();
+  return (
+    <button type="button" onClick={() => setOpen(true)}>
+      <Icon name="filter" size={48} />
+    </button>
+  );
+}
+
 export default function FilterModal({ onApply, onReset, ...props }: FilterModalProps) {
   return (
     <Dialog>
-      <DialogTrigger>
-        <Icon name="filter" />
-      </DialogTrigger>
-
+      <TriggerBtn />
       <DialogContent className="px-6 py-8">
         <FilterContent
           {...props}
           actions={
             <>
-              <Button className="w-30" onClick={onReset} variant="ghost">
+              <Button className="w-30 md:w-30" onClick={onReset} variant="ghost">
                 초기화
               </Button>
-              <Button className="w-70" onClick={onApply}>
-                필터 적용하기
-              </Button>
+              <DialogClose>
+                <Button className="md:w-70" onClick={onApply}>
+                  필터 적용하기
+                </Button>
+              </DialogClose>
             </>
           }
         />

--- a/components/wine/WineCardSkeleton.tsx
+++ b/components/wine/WineCardSkeleton.tsx
@@ -1,0 +1,30 @@
+export default function WineCardSkeleton({ showReview = true }: { showReview?: boolean }) {
+  return (
+    <article className="w-full mt-2 mb-8 lg:mb-10 rounded-2xl border border-gray-300 bg-white animate-pulse">
+      <div className="grid grid-cols-[80px_1fr] md:grid-cols-[60px_minmax(0,1fr)_auto] gap-x-4 md:gap-x-20 px-5 md:pl-15 md:pr-13 pt-2.5 items-start">
+        <div className="relative overflow-hidden row-span-2 lg:w-15 h-57 w-18 shrink-0">
+          <div className="w-full h-full bg-gray-200 rounded-md mt-5" />
+        </div>
+        <div className="col-start-2 row-start-1 mt-5 md:mt-4 space-y-2">
+          <div className="h-4 bg-gray-200 rounded w-2/3" />
+          <div className="h-3 bg-gray-200 rounded w-1/2" />
+          <div className="h-3 bg-gray-200 rounded w-1/3" />
+        </div>
+        <div className="md:mt-4 flex flex-col items-end gap-2">
+          <div className="h-4 bg-gray-200 rounded w-10" />
+          <div className="h-3 bg-gray-200 rounded w-16" />
+        </div>
+      </div>
+      {showReview && (
+        <>
+          <div className="h-px bg-gray-300" />
+          <div className="py-2 px-5 md:py-5 md:px-10 lg:px-15 space-y-2">
+            <div className="h-4 bg-gray-200 rounded w-20" />
+            <div className="h-3 bg-gray-200 rounded w-full" />
+            <div className="h-3 bg-gray-200 rounded w-5/6" />
+          </div>
+        </>
+      )}
+    </article>
+  );
+}

--- a/components/wine/list/SearchControls.tsx
+++ b/components/wine/list/SearchControls.tsx
@@ -1,0 +1,32 @@
+import FilterModal from '@/components/filter/FilterModal';
+import WineSearchBar from './WineSearchBar';
+import { FilterState } from '@/types/domain/filter';
+
+interface SearchControlsProps {
+  filter: FilterState;
+  setFilter: (v: FilterState) => void;
+  onApply: () => void;
+  onReset: () => void;
+  keyword: string;
+  onKeywordChange: (v: string) => void;
+}
+
+export default function SearchControls({
+  filter,
+  setFilter,
+  onApply,
+  onReset,
+  keyword,
+  onKeywordChange,
+}: SearchControlsProps) {
+  return (
+    <div className="flex items-start gap-2">
+      <div className="lg:hidden">
+        <FilterModal value={filter} onChange={setFilter} onApply={onApply} onReset={onReset} />
+      </div>
+      <div className="flex-1 lg:pl-15">
+        <WineSearchBar value={keyword} onChange={onKeywordChange} />
+      </div>
+    </div>
+  );
+}

--- a/components/wine/list/WineListSection.tsx
+++ b/components/wine/list/WineListSection.tsx
@@ -1,31 +1,17 @@
-import { useMemo, useState } from 'react';
-import WineSearchBar from './WineSearchBar';
 import WineList from './WineList';
 import WineListEmpty from './WineListEmpty';
 import { Wine } from '@/types/domain/wine';
 
 interface WineListSectionProps {
-  initialWines: Wine[];
+  wines: Wine[];
 }
 
-export default function WineListSection({ initialWines }: WineListSectionProps) {
-  const [keyword, setKeyword] = useState('');
-
-  const wines = initialWines;
-
-  const filtered = useMemo(() => {
-    return wines.filter(w => w.name.toLowerCase().includes(keyword.toLowerCase()));
-  }, [keyword, wines]);
-
-  const isSearching = keyword.trim().length > 0;
-  const showEmpty = isSearching && filtered.length === 0;
-  const showList = !showEmpty;
+export default function WineListSection({ wines }: WineListSectionProps) {
+  const isEmpty = wines.length === 0;
 
   return (
-    <section className="flex-1 pl-15 flex flex-col">
-      <WineSearchBar value={keyword} onChange={setKeyword} />
-      {showEmpty && <WineListEmpty />}
-      {showList && <WineList wines={filtered} />}
+    <section className="flex-1 lg:pl-15 flex flex-col">
+      {isEmpty ? <WineListEmpty /> : <WineList wines={wines} />}
     </section>
   );
 }

--- a/components/wine/list/WineListSkeleton.tsx
+++ b/components/wine/list/WineListSkeleton.tsx
@@ -1,0 +1,15 @@
+import WineCardSkeleton from '../WineCardSkeleton';
+
+interface WineListSkeletonProps {
+  count?: number;
+}
+
+export default function WineListSkeleton({ count = 6 }: WineListSkeletonProps) {
+  return (
+    <div className="flex flex-col">
+      {Array.from({ length: count }).map((_, i) => (
+        <WineCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/components/wine/list/WineSearchBar.tsx
+++ b/components/wine/list/WineSearchBar.tsx
@@ -9,7 +9,7 @@ interface WineSearchBarProps {
 
 export default function WineSearchBar({ value, onChange }: WineSearchBarProps) {
   return (
-    <div className="mb-6">
+    <div className="mb-6 w-full max-w-200">
       <Input
         value={value}
         onChange={e => onChange?.(e.target.value)}

--- a/constants/filter.ts
+++ b/constants/filter.ts
@@ -1,0 +1,10 @@
+import { FilterState } from '@/types/domain/filter';
+
+export const DEFAULT_FILTER: FilterState = {
+  type: null,
+  minPrice: 0,
+  maxPrice: 100000,
+  rating: null,
+};
+
+export const WINE_TYPES = ['RED', 'WHITE', 'SPARKLING'] as const;

--- a/hooks/list/index.ts
+++ b/hooks/list/index.ts
@@ -1,0 +1,3 @@
+export * from './useWineFilterUrlSync';
+export * from './useWineKeywordFilter';
+export * from './useWineListFetch';

--- a/hooks/list/useWineFilterUrlSync.ts
+++ b/hooks/list/useWineFilterUrlSync.ts
@@ -1,0 +1,33 @@
+import { mapFilterToUrlQuery, parseWineFilterQuery } from '@/lib/query';
+import { useRouter } from 'next/router';
+import { useEffect, useMemo, useState } from 'react';
+
+export function useWineFilterUrlSync() {
+  const router = useRouter();
+
+  const appliedFilter = useMemo(() => parseWineFilterQuery(router.query), [router.query]);
+
+  const [draftFilter, setDraftFilter] = useState(appliedFilter);
+
+  useEffect(() => {
+    setDraftFilter(appliedFilter);
+  }, [appliedFilter]);
+
+  const apply = () => {
+    router.push({ pathname: router.pathname, query: mapFilterToUrlQuery(draftFilter) }, undefined, {
+      shallow: true,
+    });
+  };
+
+  const reset = () => {
+    router.push({ pathname: router.pathname, query: {} }, undefined, { shallow: true });
+  };
+
+  return {
+    filter: draftFilter,
+    setFilter: setDraftFilter,
+    apply,
+    reset,
+    router,
+  };
+}

--- a/hooks/list/useWineKeywordFilter.ts
+++ b/hooks/list/useWineKeywordFilter.ts
@@ -1,0 +1,13 @@
+import { Wine } from '@/types/domain/wine';
+import { useMemo, useState } from 'react';
+
+export function useWineKeywordFilter(wines: Wine[]) {
+  const [keyword, setKeyword] = useState('');
+
+  const filtered = useMemo(() => {
+    const k = keyword.toLowerCase();
+    return wines.filter(w => (w.name ?? '').toLowerCase().includes(k));
+  }, [keyword, wines]);
+
+  return { keyword, setKeyword, filtered };
+}

--- a/hooks/list/useWineListFetch.ts
+++ b/hooks/list/useWineListFetch.ts
@@ -1,0 +1,41 @@
+import { getWines } from '@/lib/api/wine/wine';
+import { mapFilterToQuery, parseWineFilterQuery } from '@/lib/query';
+import { Wine } from '@/types/domain/wine';
+import { NextRouter } from 'next/router';
+import { useEffect, useRef, useState } from 'react';
+
+export function useWineListFetch(initialWines: Wine[], router: NextRouter) {
+  const [wines, setWines] = useState(initialWines);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (!router.isReady) return;
+
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      if (Object.keys(router.query).length === 0) return;
+    }
+
+    const fetchWines = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const parsed = parseWineFilterQuery(router.query);
+        const query = mapFilterToQuery(parsed);
+        const res = await getWines({ limit: 20, ...query });
+        setWines(res.list);
+      } catch {
+        setError('와인을 불러오지 못했습니다.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchWines();
+  }, [router.isReady, router.query]);
+
+  return { wines, isLoading, error };
+}

--- a/lib/query/index.ts
+++ b/lib/query/index.ts
@@ -1,0 +1,3 @@
+export * from './parseWineFilterQuery';
+export * from './mapFilterToQuery';
+export * from './mapFilterToUrlQuery';

--- a/lib/query/mapFilterToQuery.ts
+++ b/lib/query/mapFilterToQuery.ts
@@ -1,0 +1,11 @@
+import { GetWinesQuery } from '@/lib/api/wine/wine.types';
+import { FilterState } from '@/types/domain/filter';
+
+export function mapFilterToQuery(filter: FilterState): Partial<GetWinesQuery> {
+  return {
+    ...(filter.type ? { type: filter.type } : {}),
+    ...(filter.rating !== null ? { rating: filter.rating } : {}),
+    ...(filter.minPrice !== 0 ? { minPrice: filter.minPrice } : {}),
+    ...(filter.maxPrice !== 100000 ? { maxPrice: filter.maxPrice } : {}),
+  };
+}

--- a/lib/query/mapFilterToUrlQuery.ts
+++ b/lib/query/mapFilterToUrlQuery.ts
@@ -1,0 +1,16 @@
+import { FilterState } from '@/types/domain/filter';
+import type { ParsedUrlQueryInput } from 'querystring';
+
+function clean<T>(value: T | null | undefined | ''): T | undefined {
+  if (value === '' || value == null) return undefined;
+  return value;
+}
+
+export function mapFilterToUrlQuery(filter: FilterState): ParsedUrlQueryInput {
+  return {
+    type: clean(filter.type),
+    minPrice: filter.minPrice !== 0 ? String(filter.minPrice) : undefined,
+    maxPrice: filter.maxPrice !== 100000 ? String(filter.maxPrice) : undefined,
+    rating: filter.rating !== null ? String(filter.rating) : undefined,
+  };
+}

--- a/lib/query/parseWineFilterQuery.ts
+++ b/lib/query/parseWineFilterQuery.ts
@@ -1,0 +1,40 @@
+import { WINE_TYPES } from '@/constants/filter';
+import { FilterState } from '@/types/domain/filter';
+import { WineType } from '@/types/domain/wine';
+import { ParsedUrlQuery } from 'querystring';
+
+function parseInputNumber(value: string | undefined, defaultValue: number) {
+  if (value == null || value === '') return defaultValue;
+
+  const num = Number(value);
+  return Number.isNaN(num) ? defaultValue : num;
+}
+
+function parseInputNullableNumber(value: string | undefined): number | null {
+  if (value == null || value === '') return null;
+
+  const num = Number(value);
+  return Number.isNaN(num) ? null : num;
+}
+
+function parseWineType(value: string | string[] | undefined): WineType | null {
+  if (!value) return null;
+
+  const v = Array.isArray(value) ? value[0] : value;
+
+  return WINE_TYPES.includes(v as WineType) ? (v as WineType) : null;
+}
+
+function getSingle(value: string | string[] | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function parseWineFilterQuery(query: ParsedUrlQuery): FilterState {
+  return {
+    type: parseWineType(getSingle(query.type)),
+    minPrice: parseInputNumber(getSingle(query.minPrice), 0),
+    maxPrice: parseInputNumber(getSingle(query.maxPrice), 100000),
+    rating: parseInputNullableNumber(getSingle(query.rating)),
+  };
+}

--- a/types/domain/filter.ts
+++ b/types/domain/filter.ts
@@ -1,0 +1,8 @@
+import { WineType } from '@/types/domain/wine';
+
+export interface FilterState {
+  type: WineType | null;
+  minPrice: number;
+  maxPrice: number;
+  rating: number | null;
+}


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- listpage의 filter를 csr 처리하고 url query와 연동하는 작업을 진행했습니다.

## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.
(예: 이 로직을 훅으로 분리하는 게 맞는지 확신이 안 섭니다. / A방식과 B방식 중 성능 때문에 A를 택했는데 의견 궁금합니다.)

- query 변환 util 함수들을 제작하였습니다.
- parseWineFilterQuery = URL query -> 타입이 안전한 FilterState로 변환
- mapFilterToUrlQuery = FilterState -> URL query 직렬화
- mapFilterToQuery = FilterState -> API 요청 query 변환

- 데이터 / 상태 로직을 custom hook으로 분리하였습니다.
- useWineFilterUrlSync = URL/filter 상태 동기화
- useWineListFetch = router query 기반 데이터 fetch, SSR 초기 데이터 처리
- useWineKeywordFilter = 아직 임시로 client-side 검색 필터링 기능을 합니다. 다음 작업에서 query 반영으로 작업 할 예정입니다.

- filter 적용 -> wine list 변화 하는 과정에 스켈레톤을 추가했습니다.
- 현재 모달에만 초기화 버튼이 있는데, desktop side filter에도 초기화 버튼을 추가할지 고민입니다.
- 파일들을 분리하는 과정에서 file change가 좀 많아졌습니다. 필요없는 부분은 최대한 제외했으니 양해부탁드립니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
Closes #135 

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)
![listpage-filter-render](https://github.com/user-attachments/assets/1ec6a6ca-759c-4824-942b-62dd0f8a1e5b)
![listpage-filter-url](https://github.com/user-attachments/assets/757aa5b1-420b-4540-9721-2cb545ae30b3)
![listpage-modal-filter](https://github.com/user-attachments/assets/8d205e83-71c1-4cd7-a79e-1402cec19e98)
![listpge-filter-modal-reset](https://github.com/user-attachments/assets/2b2e6dab-8ae8-40ff-bd5c-c7a977612069)
