### PR TITLE
feat: 리스트페이지 캐러셀 추가 및 디자인 고도화

### DIFF
--- a/components/common/ui/Slider.tsx
+++ b/components/common/ui/Slider.tsx
@@ -37,7 +37,7 @@ export const Slider = ({
   const [nextEl, setNextEl] = useState<HTMLButtonElement | null>(null);
 
   return (
-    <div className={cn('w-full relative overflow-hidden', className)}>
+    <div className={cn('w-full relative', className)}>
       <Swiper
         modules={[Navigation, Scrollbar, Autoplay]}
         {...swiperConfig}
@@ -77,10 +77,18 @@ const NavButtons = ({
 
   return (
     <>
-      <button ref={setPrevEl} className={cn(btnClass, 'left-[0px]')} aria-label="이전">
+      <button
+        ref={setPrevEl}
+        className={cn(btnClass, 'md:left-[0px]', 'lg:left-[-30px]')}
+        aria-label="이전"
+      >
         <NextImage src={prevIcon} alt="" width={48} height={48} priority />
       </button>
-      <button ref={setNextEl} className={cn(btnClass, 'right-[0px]')} aria-label="다음">
+      <button
+        ref={setNextEl}
+        className={cn(btnClass, 'md:right-[0px]', 'lg:right-[-30px]')}
+        aria-label="다음"
+      >
         <NextImage src={nextIcon} alt="" width={48} height={48} priority />
       </button>
     </>

--- a/components/wine/WineRecommendedCard.tsx
+++ b/components/wine/WineRecommendedCard.tsx
@@ -22,8 +22,8 @@ const CARD_VARIANTS = {
   },
   list: {
     base: 'overflow-hidden',
-    title: 'text-gray-900 text-sm leading-5 h-10 overflow-hidden break-keep mt-4 font-bold',
-    sub: 'text-gray-500 text-xs h-5 overflow-hidden whitespace-nowrap mt-1',
+    title: 'text-gray-900 text-basic leading-5 h-10 overflow-hidden break-keep mt-4 font-bold',
+    sub: 'text-gray-500 text-sm h-5 overflow-hidden whitespace-nowrap mt-1',
   },
 } as const;
 

--- a/components/wine/landing/LandingCarousel.tsx
+++ b/components/wine/landing/LandingCarousel.tsx
@@ -46,13 +46,11 @@ export const LandingCarousel = ({ wineList }: LandingCarouselProps) => {
       >
         <div className="relative z-10">
           {' '}
-          {/* 여백 조절용 */}
           <Slider {...LANDING_PRESET} itemKeys={wineList.map(wine => wine.id)}>
             {wineList.map(wine => {
               return function SliderItem({ isActive }: { isActive?: boolean }) {
                 return (
                   <div className="relative flex justify-center items-center">
-                    {/* 실제 와인 카드 */}
                     <div className="relative z-10 w-full">
                       <WineRecommendedCard wine={wine} isActive={isActive} variant="landing" />
                     </div>

--- a/components/wine/list/HeroSection.tsx
+++ b/components/wine/list/HeroSection.tsx
@@ -1,15 +1,15 @@
 import Container from '@/components/common/layout/Container';
 import Gnb from '@/components/common/layout/Gnb';
+import { ListCarousel } from '@/components/wine/list/ListCarousel';
+import { mockWineData } from '@/mock/wine.mock';
 
+const wineList = mockWineData.list;
 export default function HeroSection() {
   return (
-    <div className="bg-gray-50 pt-px">
+    <div className="w-full bg-gray-50 pt-px lg:rounded-b-[88px] pb-6 md:pb-0">
       <Gnb />
-
       <Container>
-        <section className=" h-100 rounded-xl bg-gray-100 flex items-center justify-center">
-          <span className="text-gray-400">carousel placeholder</span>
-        </section>
+        <ListCarousel wineList={wineList} />
       </Container>
     </div>
   );

--- a/components/wine/list/ListCarousel.tsx
+++ b/components/wine/list/ListCarousel.tsx
@@ -33,21 +33,19 @@ const SCROLLBAR_STYLES = cn(
 
 export const ListCarousel = ({ wineList }: ListCarouselProps) => {
   return (
-    <section className="w-full">
-      <div className="w-full px-4 lg:px-12">
-        <Slider
-          {...LIST_PRESET}
-          itemKeys={wineList.map(wine => wine.id)}
-          showNavigation={true}
-          scrollbarStyles={SCROLLBAR_STYLES}
-        >
-          {wineList.map(wine => (
-            <div key={wine.id} className="flex flex-col group w-full">
-              <WineRecommendedCard wine={wine} isActive={false} variant="list" />
-            </div>
-          ))}
-        </Slider>
-      </div>
+    <section className="w-full max-w-300 lg:m-auto">
+      <Slider
+        {...LIST_PRESET}
+        itemKeys={wineList.map(wine => wine.id)}
+        showNavigation={true}
+        scrollbarStyles={SCROLLBAR_STYLES}
+      >
+        {wineList.map(wine => (
+          <div key={wine.id} className="flex flex-col group w-full">
+            <WineRecommendedCard wine={wine} isActive={false} variant="list" />
+          </div>
+        ))}
+      </Slider>
     </section>
   );
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -78,7 +78,9 @@ export default function Home() {
         </div>
         <div className="flex justify-center pt-0 pb-16 lg:pb-32">
           <Link href="/wines">
-            <Button className="w-72 bg-zinc-950 text-lg font-bold">와인 보러가기</Button>
+            <Button className="w-72 bg-zinc-950 text-lg font-bold cursor-pointer">
+              와인 보러가기
+            </Button>
           </Link>
         </div>
       </Container>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -78,9 +78,7 @@ export default function Home() {
         </div>
         <div className="flex justify-center pt-0 pb-16 lg:pb-32">
           <Link href="/wines">
-            <Button className="w-72 bg-zinc-950 text-lg font-bold cursor-pointer">
-              와인 보러가기
-            </Button>
+            <Button className="w-72 bg-zinc-950 text-lg font-bold">와인 보러가기</Button>
           </Link>
         </div>
       </Container>


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

리스페이지 상단 캐러셀 추가 

## 같이 고민해 주세요 (리뷰 포인트)

-  캐러셀 버튼 위치 조정 수정 
- 와인 이름, 원산지 글씨 크기 수정
- 랜딩페이지 하단 버튼 커서 추가를 안해서 같이 수정했습니다 ㅠ 

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #146 )

## 테스트 결과 (스크린샷)
pc
<img width="1656" height="568" alt="스크린샷 2026-02-19 오후 9 37 57" src="https://github.com/user-attachments/assets/b2f92b83-64eb-4c14-8599-aa21b85536bf" />
 태블릿
<img width="617" height="447" alt="스크린샷 2026-02-19 오후 9 38 25" src="https://github.com/user-attachments/assets/342fbba2-85ed-4da9-9058-c4dc17912afa" />
모바일 
<img width="448" height="446" alt="스크린샷 2026-02-19 오후 9 38 11" src="https://github.com/user-attachments/assets/28118d8d-b1c8-4db6-a611-9944d3312855" />


