### PR TITLE
feat: 랜딩캐러셀 api연동

### DIFF
--- a/components/wine/WineRecommendedCard.tsx
+++ b/components/wine/WineRecommendedCard.tsx
@@ -13,9 +13,10 @@ const CARD_VARIANTS = {
   landing: {
     base: 'bg-transparent border-transparent',
     active: 'bg-zinc-900 shadow-2xl border-1 border-zinc-700',
-    title: 'text-zinc-700 text-xs min-h-[32px] line-clamp-2 break-keep font-medium mb-1',
+    title:
+      'text-zinc-700 text-xs min-h-[32px] line-clamp-2 overflow-hidden break-keep font-medium mb-1',
     activeTitle:
-      'ext-white text-sm lg:text-base leading-tight min-h-[38px] lg:min-h-[48px] line-clamp-2 break-keep mb-1',
+      'ext-white text-sm lg:text-base leading-tight min-h-[36px] lg:min-h-[42px] line-clamp-2 break-keep mb-1',
     sub: 'text-zinc-600 text-xs whitespace-nowrap overflow-hidden h-4',
     activeSub:
       'text-zinc-400 text-[10px] lg:text-sm whitespace-nowrap overflow-hidden text-ellipsis h-5',

--- a/components/wine/landing/LandingCarousel.tsx
+++ b/components/wine/landing/LandingCarousel.tsx
@@ -30,7 +30,7 @@ const LANDING_PRESET: SwiperOptions = {
 };
 
 export const LandingCarousel = ({ wineList }: LandingCarouselProps) => {
-  if (!wineList || wineList.length === 0) return null;
+  if (wineList.length === 0) return null;
 
   return (
     <section className="relative w-full">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,10 +7,16 @@ import Container from '@/components/common/layout/Container';
 import Gnb from '@/components/common/layout/Gnb';
 import Button from '@/components/common/ui/Button';
 import { LandingCarousel } from '@/components/wine/landing/LandingCarousel';
-import { mockWineData } from '@/mock/wine.mock';
+import { GetStaticProps } from 'next';
+import { getRecommendedWines } from '@/lib/api/wine/wine';
+import { Wine } from '@/types/domain/wine';
 
-export default function Home() {
-  const wineList = mockWineData.list;
+interface HomeProps {
+  recommendedWines: Wine[];
+}
+const RECOMMENDED_WINE_LIMIT = 12;
+
+export default function Home({ recommendedWines }: HomeProps) {
   return (
     <main>
       <section className="bg-zinc-950 text-white pt-5">
@@ -22,7 +28,7 @@ export default function Home() {
             <br />
             나만의 와인창고
           </h2>
-          <LandingCarousel wineList={wineList} />
+          {recommendedWines.length > 0 && <LandingCarousel wineList={recommendedWines} />}
         </Container>
       </section>
       <Container className="flex flex-col">
@@ -85,3 +91,24 @@ export default function Home() {
     </main>
   );
 }
+
+export const getStaticProps: GetStaticProps = async () => {
+  try {
+    const recommendedWines = await getRecommendedWines(RECOMMENDED_WINE_LIMIT);
+
+    return {
+      props: {
+        recommendedWines,
+      },
+      revalidate: 3600,
+    };
+  } catch (error) {
+    console.error('추천 와인 로드 실패:', error);
+    return {
+      props: {
+        recommendedWines: [],
+      },
+      revalidate: 60,
+    };
+  }
+};


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

랜딩페이지 캐러셀 추천와인 api연동 

## 같이 고민해 주세요 (리뷰 포인트)
- getStaticProps를 사용
- revalidate 1시간 주기로 데이터가 자동 갱신되도록 설정
- 호출 실패 시 빈 배열 반환 revalidate 60설정
- 호출 제한 수 RECOMMENDED_WINE_LIMIT 12로 설정했습니다 
- 와인이름 높이조절 (추천와인컴포넌트 수정)  

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #158)

## 테스트 결과 (스크린샷)
pc
<img width="1599" height="752" alt="스크린샷 2026-02-20 오후 3 11 06" src="https://github.com/user-attachments/assets/b15c92f4-1bbe-4afb-8182-6d6768fa1769" />
mo
<img width="541" height="568" alt="스크린샷 2026-02-20 오후 3 11 23" src="https://github.com/user-attachments/assets/0c4938c8-50e0-4757-b0aa-01e9b5d710cc" />



