### PR TITLE
feat: auth 페이지 form 벨리데이션 연동

### DIFF
--- a/hooks/useForm/types.ts
+++ b/hooks/useForm/types.ts
@@ -27,3 +27,7 @@ export interface Field<TFieldValues extends Record<string, unknown> = Record<str
 export interface useFormProps {
   mode?: FormMode;
 }
+
+export type FieldErrors<TFieldValues extends Record<string, unknown>> = Partial<
+  Record<keyof TFieldValues, string>
+>;

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -2,19 +2,61 @@ import AuthLayout from '@/components/common/layout/AuthLayout';
 import FormField from '@/components/common/form/FormField';
 import Button from '@/components/common/ui/Button';
 import Link from 'next/link';
+import { useForm } from '@/hooks/useForm/useForm';
+import type { FieldErrors } from '@/hooks/useForm/types';
+
+import { useAuth } from '@/providers/Auth/AuthProvider';
+
+type SignInValues = {
+  email: string;
+  password: string;
+};
 
 export default function SignIn() {
+  const { login } = useAuth();
+  const { register, handleSubmit, errors } = useForm<SignInValues>({ mode: 'onSubmit' });
+
+  const valid = async (data: SignInValues) => {
+    const response = await login(data);
+    if (response.success) {
+      console.log('로그인 성공 테스트.');
+    } else {
+      console.log('로그인 실패!');
+    }
+  };
+
+  const inValid = (formErrors: FieldErrors<SignInValues>) => {
+    console.log('실패했을때.', formErrors);
+  };
+
   return (
     <AuthLayout>
-      <form className="flex flex-col">
+      <form className="flex flex-col" onSubmit={handleSubmit(valid, inValid)}>
         <div className="flex flex-col gap-6 mb-10">
-          <FormField id="email" label="이메일" placeholder="이메일을 입력해주세요" type="text" />
+          <FormField
+            id="email"
+            label="이메일"
+            placeholder="이메일을 입력해주세요"
+            type="text"
+            {...register('email', {
+              required: '이메일을 입력해주세요',
+              pattern: {
+                value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+                message: '올바른 이메일 형식이 아닙니다',
+              },
+            })}
+            error={errors.email}
+          />
 
           <FormField
             id="password"
             label="비밀번호"
             placeholder="비밀번호를 입력해주세요"
             type="password"
+            {...register('password', {
+              required: '비밀번호를 입력해주세요',
+            })}
+            error={errors.password}
           />
         </div>
 

--- a/pages/auth/signup.tsx
+++ b/pages/auth/signup.tsx
@@ -1,0 +1,109 @@
+import AuthLayout from '@/components/common/layout/AuthLayout';
+import FormField from '@/components/common/form/FormField';
+import Button from '@/components/common/ui/Button';
+import Link from 'next/link';
+import { useForm } from '@/hooks/useForm/useForm';
+import type { FieldErrors } from '@/hooks/useForm/types';
+
+type SignUpValues = {
+  email: string;
+  nickname: string;
+  password: string;
+  passwordConfirmation: string;
+};
+
+export default function SignUp() {
+  const { register, handleSubmit, errors } = useForm<SignUpValues>({ mode: 'onBlur' });
+
+  const valid = async (data: SignUpValues) => {
+    console.log('회원가입 시도', data);
+  };
+
+  const inValid = (formErrors: FieldErrors<SignUpValues>) => {
+    console.log('실패했을때.', formErrors);
+  };
+
+  return (
+    <AuthLayout>
+      <form className="flex flex-col" onSubmit={handleSubmit(valid, inValid)}>
+        <div className="flex flex-col gap-6 mb-10">
+          <FormField
+            id="email"
+            label="이메일"
+            placeholder="이메일을 입력해주세요"
+            type="text"
+            {...register('email', {
+              required: '이메일을 입력해주세요',
+              pattern: {
+                value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+                message: '올바른 이메일 형식이 아닙니다',
+              },
+            })}
+            error={errors.email}
+          />
+
+          <FormField
+            id="nickname"
+            label="닉네임"
+            placeholder="닉네임을 입력해주세요"
+            type="text"
+            {...register('nickname', {
+              required: '닉네임을 입력해주세요',
+              minLength: {
+                value: 2,
+                message: '닉네임은 2자 이상이어야 합니다',
+              },
+              maxLength: {
+                value: 10,
+                message: '닉네임은 10자 이하이어야 합니다',
+              },
+            })}
+            error={errors.nickname}
+          />
+
+          <FormField
+            id="password"
+            label="비밀번호"
+            placeholder="비밀번호를 입력해주세요"
+            type="password"
+            {...register('password', {
+              required: '비밀번호를 입력해주세요',
+              minLength: {
+                value: 8,
+                message: '비밀번호는 8자 이상이어야 합니다',
+              },
+              deps: ['passwordConfirmation'],
+            })}
+            error={errors.password}
+          />
+
+          <FormField
+            id="passwordConfirmation"
+            label="비밀번호 확인"
+            placeholder="비밀번호를 다시 입력해주세요"
+            type="password"
+            {...register('passwordConfirmation', {
+              required: '비밀번호 확인을 입력해주세요',
+              validate: (value, values) =>
+                value === values.password ? undefined : '비밀번호가 일치하지 않습니다',
+            })}
+            error={errors.passwordConfirmation}
+          />
+        </div>
+
+        <div className="flex flex-col gap-8">
+          <Button type="submit" className="h-[50px]">
+            가입하기
+          </Button>
+
+          <div className="flex justify-center items-center gap-2 text-sm">
+            <span className="text-muted-foreground">계정이 있으신가요?</span>
+            <Link href="/auth/signin" className="text-primary underline font-medium">
+              로그인하기
+            </Link>
+          </div>
+        </div>
+      </form>
+    </AuthLayout>
+  );
+}

--- a/providers/Auth/AuthProvider.tsx
+++ b/providers/Auth/AuthProvider.tsx
@@ -30,7 +30,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const login = useCallback(async (credentials: SignInCredentials): Promise<LoginResponse> => {
     try {
-      const response = await fetch('/api/auth/signin', {
+      const response = await fetch('/api/proxy/auth/signin', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -42,7 +42,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       if (response.ok) {
         setUser(data);
-        return { success: true, user: data };
+        return { success: true };
       }
       return { success: false, error: data.message };
     } catch (error) {
@@ -53,7 +53,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(async () => {
     try {
-      await fetch('/api/auth/logout', { method: 'POST' });
+      await fetch('/api/proxy/auth/logout', { method: 'POST' });
       setUser(null);
     } catch (error) {
       console.error('로그아웃 중 오류 발생:', error);

--- a/providers/Auth/types.ts
+++ b/providers/Auth/types.ts
@@ -6,7 +6,7 @@ export interface User {
   image: string | null;
 }
 
-export type LoginResponse = { success: true; user: User } | { success: false; error: string };
+export type LoginResponse = { success: true } | { success: false; error: string };
 
 export interface AuthContextValue {
   isLoading: boolean;


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- 로그인 및 회원가입 페이지 Form 검증 작업
- useForm InVaild 상황에서 타입정의가 매우 불편한 이슈가 있어서 별도 type 을 추가

## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.
(예: 이 로직을 훅으로 분리하는 게 맞는지 확신이 안 섭니다. / A방식과 B방식 중 성능 때문에 A를 택했는데 의견 궁금합니다.)

- 기존에는 로그인에 성공했을때 user 객체를 같이 내려줬습니다.
이 부분은 provider 에 들어갈값이라서 제거했는데 로그인 성공시 user 값이 필요할지 의견부탁드립니다 :)

- 기존에 onBlur 모드에서 onTouched 처럼 작동하는 부분은 수정했습니다. 사실상 필요한 모드가 onTouched 말고는 없을거같긴합니다..

- 로그인페이지에는 onSubmit 으로 적용했습니다. blur, change 발생시 아무런 작동하지않으며 실제 전송버튼이 눌렸을때만 검증하도록 했습니다. 로그인 페이지 ux 의견부탁드립니다! 
  - 부가적으로 로그인페이지에서는 비밀번호 길이를 검증하고있지않고 이메일과 비밀번호 필수입력만 받고있습니다. 비밀번호 길이가 필수조건이라는걸 알 수 없도록 처리했습니다.

- 위 부분에 대한 이유는 자주 사용하던 방법입니다.. 사이트마다 비밀번호 규칙이 다르다보니 어느사이트는 2글자, 어디는 4글자 등 조건이 있는데 이 부분에 대한 조건을 알 수 있으면 비밀번호 조건을 알려주기에 오히려 취약하다고 생각해서 필수입력만 받도록 했습니다. 

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #151 )

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)

<img width="519" height="833" alt="image" src="https://github.com/user-attachments/assets/d321e8eb-32e2-4821-8cf9-839323f9b689" />

