### PR TITLE
feat: listpage infinite scroll 적용 및 상세 페이지 이동 연결

### DIFF
--- a/components/wine/WineCard.tsx
+++ b/components/wine/WineCard.tsx
@@ -2,6 +2,7 @@ import { Wine } from '@/types/domain/wine';
 import WineInfo from './WineInfo';
 import Image from 'next/image';
 import WineMeta from './WineMeta';
+import Link from 'next/link';
 
 interface WineCardProps {
   wine: Wine;
@@ -10,30 +11,32 @@ interface WineCardProps {
 export default function WineCard({ wine }: WineCardProps) {
   const { image, name, region, price, avgRating, reviewCount, recentReview } = wine;
   return (
-    <article className="w-full mt-2 mb-8 lg:mb-10 rounded-2xl border border-gray-300 bg-white hover:shadow-md transition">
-      <div className="grid grid-cols-[80px_1fr] md:grid-cols-[60px_minmax(0,1fr)_auto] gap-x-4 md:gap-x-20 px-5 md:pl-15 md:pr-13 pt-2.5 items-start">
-        <div className="relative overflow-hidden row-span-2 lg:w-15 h-57 w-18 shrink-0">
-          <Image src={image} alt={name} fill className="object-cover mt-5" />
-        </div>
-        <div className="col-start-2 row-start-1 mt-5 md:mt-4">
-          <WineInfo name={name} region={region} price={price} />
-        </div>
-        <div className="md:mt-4">
-          <WineMeta avgRating={avgRating} reviewCount={reviewCount} />
-        </div>
-      </div>
-
-      {recentReview && (
-        <>
-          <div className="h-px bg-gray-300" />
-          <div className="py-2 px-5 md:py-5 md:px-10 lg:px-15">
-            <p className="mb-2 md:mb-2.5 text-sm md:text-base font-medium">최신 후기</p>
-            <p className="text-sm text-gray-400 leading-6 line-clamp-2 md:text-wrap">
-              {recentReview.content}
-            </p>
+    <Link href={`/wines/${wine.id}`} className="block">
+      <article className="w-full mt-2 mb-8 lg:mb-10 rounded-2xl border border-gray-300 bg-white hover:shadow-md transition">
+        <div className="grid grid-cols-[80px_1fr] md:grid-cols-[60px_minmax(0,1fr)_auto] gap-x-4 md:gap-x-20 px-5 md:pl-15 md:pr-13 pt-2.5 items-start">
+          <div className="relative overflow-hidden row-span-2 lg:w-15 h-57 w-18 shrink-0">
+            <Image src={image} alt={name} fill className="object-cover mt-5" />
           </div>
-        </>
-      )}
-    </article>
+          <div className="col-start-2 row-start-1 mt-5 md:mt-4">
+            <WineInfo name={name} region={region} price={price} />
+          </div>
+          <div className="md:mt-4">
+            <WineMeta avgRating={avgRating} reviewCount={reviewCount} />
+          </div>
+        </div>
+
+        {recentReview && (
+          <>
+            <div className="h-px bg-gray-300" />
+            <div className="py-2 px-5 md:py-5 md:px-10 lg:px-15">
+              <p className="mb-2 md:mb-2.5 text-sm md:text-base font-medium">최신 후기</p>
+              <p className="text-sm text-gray-400 leading-6 line-clamp-2 md:text-wrap">
+                {recentReview.content}
+              </p>
+            </div>
+          </>
+        )}
+      </article>
+    </Link>
   );
 }

--- a/hooks/list/useWineFilterUrlSync.ts
+++ b/hooks/list/useWineFilterUrlSync.ts
@@ -17,6 +17,7 @@ export function useWineFilterUrlSync() {
     router.push({ pathname: router.pathname, query: mapFilterToUrlQuery(draftFilter) }, undefined, {
       shallow: true,
     });
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   const reset = () => {

--- a/hooks/list/useWineListFetch.ts
+++ b/hooks/list/useWineListFetch.ts
@@ -4,10 +4,12 @@ import { Wine } from '@/types/domain/wine';
 import { NextRouter } from 'next/router';
 import { useEffect, useRef, useState } from 'react';
 
-export function useWineListFetch(initialWines: Wine[], router: NextRouter) {
+export function useWineListFetch(initialWines: Wine[], router: NextRouter, initialCursor?: number) {
   const [wines, setWines] = useState(initialWines);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [cursor, setCursor] = useState<number | undefined>(initialCursor);
+  const [hasNextPage, setHasNextPage] = useState(!!initialCursor);
   const isFirstRender = useRef(true);
 
   useEffect(() => {
@@ -27,6 +29,8 @@ export function useWineListFetch(initialWines: Wine[], router: NextRouter) {
         const query = mapFilterToQuery(parsed);
         const res = await getWines({ limit: 20, ...query });
         setWines(res.list);
+        setCursor(res.nextCursor ?? undefined);
+        setHasNextPage(!!res.nextCursor);
       } catch {
         setError('와인을 불러오지 못했습니다.');
       } finally {
@@ -37,5 +41,30 @@ export function useWineListFetch(initialWines: Wine[], router: NextRouter) {
     fetchWines();
   }, [router.isReady, router.query]);
 
-  return { wines, isLoading, error };
+  const fetchNextPage = async () => {
+    if (!hasNextPage || isLoading) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const parsed = parseWineFilterQuery(router.query);
+      const query = mapFilterToQuery(parsed);
+
+      const res = await getWines({
+        limit: 20,
+        ...(cursor !== undefined ? { cursor } : {}),
+        ...query,
+      });
+      setWines(prev => [...prev, ...res.list]);
+      setCursor(res.nextCursor ?? undefined);
+      setHasNextPage(!!res.nextCursor);
+    } catch {
+      setError('와인을 불러오지 못했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { wines, isLoading, error, hasNextPage, fetchNextPage };
 }

--- a/pages/wines/index.tsx
+++ b/pages/wines/index.tsx
@@ -6,22 +6,23 @@ import { GetStaticProps } from 'next';
 
 interface WineListPageProps {
   initialWines: Wine[];
+  initialCursor?: number;
 }
 
 export const getStaticProps: GetStaticProps<WineListPageProps> = async () => {
   try {
     const res = await getWines({ limit: 20 });
-    return { props: { initialWines: res.list }, revalidate: 60 };
+    return { props: { initialWines: res.list, initialCursor: res.nextCursor }, revalidate: 60 };
   } catch (e) {
-    return { props: { initialWines: [] }, revalidate: 60 };
+    return { props: { initialWines: [], initialCursor: undefined }, revalidate: 60 };
   }
 };
 
-export default function WineListPage({ initialWines }: WineListPageProps) {
+export default function WineListPage({ initialWines, initialCursor }: WineListPageProps) {
   return (
     <>
       <HeroSection />
-      <WineListLayout initialWines={initialWines} />
+      <WineListLayout initialWines={initialWines} initialCursor={initialCursor} />
     </>
   );
 }


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- listpage list에 infinite scroll 적용
- 카드 클릭 시 상세 페이지 이동 연결

## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.
(예: 이 로직을 훅으로 분리하는 게 맞는지 확신이 안 섭니다. / A방식과 B방식 중 성능 때문에 A를 택했는데 의견 궁금합니다.)

- list page에 cursor 기반 infinite scroll을 구현하고, 각 와인 카드 클릭 시 상세 페이지(`/wines/{wineId}`)로 이동하도록 연결했습니다.
- SSR로 초기 데이터를 렌더링한 뒤, 스크롤 하단 도달 시 다음 페이지를 자동으로 로딩하여 리스트에 appned 하게 했습니다.
- 다음 작업으로 모달 연결을 하려고 하는데, 우측 하단에 와인 등록 버튼을 놓았을 때 모바일 환경에서는 어떻게 적용시키면 될 지 고민입니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
Closes #157 

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)

https://github.com/user-attachments/assets/12e80425-1454-44d6-abd7-8bc7f8d45afe

