### PR TITLE
feat: 상세페이지 api연동

### DIFF
--- a/components/review/AromaBadge.tsx
+++ b/components/review/AromaBadge.tsx
@@ -1,15 +1,19 @@
-import { AROMA_META } from '@/constants/aromaMap';
+import { AROMA_META, AromaType } from '@/constants/aromaMap';
 
 interface AromaBadgeProps {
-  type: keyof typeof AROMA_META;
+  type: string;
 }
 
 export default function AromaBadge({ type }: AromaBadgeProps) {
-  const { label, icon } = AROMA_META[type];
+  const meta = AROMA_META[type.toUpperCase() as AromaType];
+
+  if (!meta) return null;
+
+  const { label, icon } = meta;
 
   return (
     <div className="flex items-center gap-2 text-muted-foreground">
-      <img src={icon.src} alt="" aria-hidden className="w-6 h-6" />
+      {icon?.src && <img src={icon.src} alt={label} aria-hidden className="w-6 h-6" />}
       <span className="text-gray-400">{label}</span>
     </div>
   );

--- a/components/review/ReviewUser.tsx
+++ b/components/review/ReviewUser.tsx
@@ -11,11 +11,7 @@ export default function ReviewUser({ user, createdAt }: ReviewUserProps) {
 
   return (
     <div className="flex items-center gap-4 text-gray-500">
-      <img
-        src={user.image ?? undefined}
-        alt={user.nickname}
-        className="w-16 h-16 rounded-full object-cover"
-      />
+      <img src={user.image ?? undefined} className="w-16 h-16 rounded-full object-cover" />
       <div className="flex flex-col items-start">
         <span className="font-semibold text-muted-foreground text-lg">{user.nickname}</span>
         <span className="text-gray-400">{formatTimeAgo(date)}</span>

--- a/components/review/ReviewUser.tsx
+++ b/components/review/ReviewUser.tsx
@@ -3,16 +3,22 @@ import { formatTimeAgo } from '@/utils/formatTimeAgo';
 
 interface ReviewUserProps {
   user: UserInReview;
-  createdAt: Date;
+  createdAt: string | Date;
 }
 
 export default function ReviewUser({ user, createdAt }: ReviewUserProps) {
+  const date = typeof createdAt === 'string' ? new Date(createdAt) : createdAt;
+
   return (
     <div className="flex items-center gap-4 text-gray-500">
-      <img src={user.image} alt={user.name} className="w-16 h-16 rounded-full object-cover" />
+      <img
+        src={user.image ?? undefined}
+        alt={user.nickname}
+        className="w-16 h-16 rounded-full object-cover"
+      />
       <div className="flex flex-col items-start">
-        <span className="font-semibold text-muted-foreground text-lg">{user.name}</span>
-        <span className="text-gray-400">{formatTimeAgo(createdAt)}</span>
+        <span className="font-semibold text-muted-foreground text-lg">{user.nickname}</span>
+        <span className="text-gray-400">{formatTimeAgo(date)}</span>
       </div>
     </div>
   );

--- a/components/reviewCard/ReviewFeedCard.tsx
+++ b/components/reviewCard/ReviewFeedCard.tsx
@@ -1,4 +1,3 @@
-import { Review } from '@/types/domain/review';
 import IconButton from '@/components/common/ui/IconButton';
 import ReviewUser from '../review/ReviewUser';
 import ReviewRating from '../review/ReviewRating';
@@ -8,37 +7,23 @@ import ReviewContainer from '../review/ReviewContainer';
 import ChevronToggleButton from '../review/ChevronToggleButton';
 import { useState } from 'react';
 import ReviewMenu from '../review/ReviewMenu';
-import TasteItem, { TASTES, Taste as TasteLabel } from '@/components/common/ui/TasteItem';
+import TasteItem, { TASTES } from '@/components/common/ui/TasteItem';
+import { ApiWineReview } from '@/lib/api/wine/wine.types';
+import { getTasteValueByLabel } from '@/utils/tasteValue';
+import { AromaType } from '@/constants/aromaMap';
 
 interface ReviewFeedCardProps {
-  review: Review;
+  review: ApiWineReview;
   isOwner: boolean;
+  onDelete: (id: number) => void;
+  onLike: () => void;
 }
 
-export default function ReviewFeedCard({ review, isOwner }: ReviewFeedCardProps) {
+export default function ReviewFeedCard({ review, isOwner, onDelete, onLike }: ReviewFeedCardProps) {
   const [expanded, setExpanded] = useState(false);
 
-  const handleEdit = (reviewId: number) => {
-    console.log('모달');
-  };
-
-  const handleDelete = (reviewId: number) => {
-    console.log('모달');
-  };
-  // 임시! 데이터 연결시 따로 파일분리 예정
-  const getTasteValue = (tasteName: TasteLabel) => {
-    switch (tasteName) {
-      case '바디감':
-        return review.tastes.body;
-      case '탄닌':
-        return review.tastes.tannin;
-      case '당도':
-        return review.tastes.sweetness;
-      case '산미':
-        return review.tastes.acidity;
-      default:
-        return 0;
-    }
+  const handleEdit = () => {
+    console.log('수정 모달 오픈:', review.id);
   };
 
   /**
@@ -56,16 +41,21 @@ export default function ReviewFeedCard({ review, isOwner }: ReviewFeedCardProps)
             <div className="flex flex-col justify-center">
               <ReviewUser user={review.user} createdAt={review.createdAt} />
             </div>
+
             {isOwner ? (
-              <ReviewMenu reviewId={review.id} onEdit={handleEdit} onDelete={handleDelete} />
+              <ReviewMenu
+                reviewId={review.id}
+                onEdit={handleEdit}
+                onDelete={() => onDelete(review.id)}
+              />
             ) : (
-              <IconButton icon="heart" size={28} />
+              <IconButton icon="heart" size={28} onClick={onLike} />
             )}
           </div>
         </div>
       }
     >
-      <AromaList aromas={review.aroma} />
+      <AromaList aromas={review.aroma as AromaType[]} />
       <ReviewContent content={review.content} />
       {expanded && (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-x-10 gap-y-4 mt-6">
@@ -73,7 +63,7 @@ export default function ReviewFeedCard({ review, isOwner }: ReviewFeedCardProps)
             <TasteItem
               key={`${review.id}-${name}`}
               taste={name}
-              value={getTasteValue(name)}
+              value={getTasteValueByLabel(review, name)}
               variant="review"
             />
           ))}

--- a/components/wine/detail/HeroSection.tsx
+++ b/components/wine/detail/HeroSection.tsx
@@ -13,7 +13,7 @@ export default function HeroSection({ wine }: HeroSectionProps) {
       <Gnb />
 
       <Container>
-        {/* 데이터연동을 위해 임시로 넣은 것 지현이 작업중 */}
+        {/* 데이터연동을 위해 임시로 넣은 것 지현님 작업중 */}
         <section className="bg-gray-900 lg:py-12 flex flex-col lg:flex-row items-center gap-8 lg:gap-16">
           <div className="relative w-full max-w-[300px] h-[400px]">
             {wine.image && !wine.image.includes('placeholder') ? (

--- a/components/wine/detail/HeroSection.tsx
+++ b/components/wine/detail/HeroSection.tsx
@@ -1,14 +1,42 @@
 import Container from '@/components/common/layout/Container';
 import Gnb from '@/components/common/layout/Gnb';
+import { GetWineDetailResponse } from '@/lib/api/wine/wine.types';
+import Image from 'next/image';
 
-export default function HeroSection() {
+interface HeroSectionProps {
+  wine: GetWineDetailResponse;
+}
+
+export default function HeroSection({ wine }: HeroSectionProps) {
   return (
-    <div className="bg-gray-50 pt-px lg:rounded-b-[88px]">
+    <div className="pt-px text-white overflow-hidden">
       <Gnb />
 
       <Container>
-        <section className=" h-[400px] flex items-center justify-center">
-          <span className="text-gray-400">와인 상세 정보</span>
+        {/* 데이터연동을 위해 임시로 넣은 것 지현이 작업중 */}
+        <section className="bg-gray-900 lg:py-12 flex flex-col lg:flex-row items-center gap-8 lg:gap-16">
+          <div className="relative w-full max-w-[300px] h-[400px]">
+            {wine.image && !wine.image.includes('placeholder') ? (
+              <Image src={wine.image} alt={wine.name} fill className="object-contain" priority />
+            ) : (
+              <div className="w-full h-full bg-gray-800 flex flex-col items-center justify-center text-gray-400">
+                <span>이미지 준비 중</span>
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-4 text-center lg:text-left">
+            <div className="flex flex-col gap-2">
+              <span className="text-purple-400 font-medium tracking-wider uppercase text-sm">
+                {wine.region}
+              </span>
+              <h1 className="text-4xl lg:text-5xl font-bold leading-tight">{wine.name}</h1>
+            </div>
+
+            <div className="mt-4">
+              <span className="text-3xl font-bold">₩ {wine.price.toLocaleString()}</span>
+            </div>
+          </div>
         </section>
       </Container>
     </div>

--- a/components/wine/detail/ReviewEmpty.tsx
+++ b/components/wine/detail/ReviewEmpty.tsx
@@ -1,0 +1,33 @@
+import emptyIcon from '@/assets/images/empty.png';
+import Image from 'next/image';
+import Button from '@/components/common/ui/Button';
+
+interface ReviewEmptyProps {
+  onWriteClick?: () => void;
+}
+
+export default function ReviewEmpty({ onWriteClick }: ReviewEmptyProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center  w-full">
+      <Image
+        src={emptyIcon}
+        alt=""
+        aria-hidden
+        width={136}
+        height={136}
+        className="mb-4 opacity-80 w-24 h-24 lg:w-[136px] lg:h-[136px] object-contain"
+      />
+
+      <p className="text-basic md:text-xl font-semibold text-muted-foreground mb-3">
+        작성된 리뷰가 없습니다.
+      </p>
+      <Button
+        variant="primary"
+        className="w-52 mx-auto py-3 rounded-full text-lg font-bold shadow-md hover:shadow-lg transition-all active:scale-95 mt-4"
+        onClick={onWriteClick}
+      >
+        리뷰 작성하기
+      </Button>
+    </div>
+  );
+}

--- a/components/wine/detail/ReviewSection.tsx
+++ b/components/wine/detail/ReviewSection.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import Button from '@/components/common/ui/Button';
 import ReviewFeedCard from '@/components/reviewCard/ReviewFeedCard';
 import ReviewStats from '@/components/wine/detail/ReviewStats';
+import ReviewEmpty from '@/components/wine/detail/ReviewEmpty';
 import { useReviewStats } from '@/hooks/useReviewStats';
 import { GetWineDetailResponse, ApiWineReview } from '@/lib/api/wine/wine.types';
 import { deleteReview, likeReview, unlikeReview } from '@/lib/api/review/review';
@@ -56,12 +57,12 @@ export default function ReviewSection({ wine, myId }: ReviewSectionProps) {
   // 리뷰가 없을 때 UI
   if (!reviews || reviews.length === 0) {
     return (
-      <div className="flex flex-col items-center py-20 bg-gray-50 rounded-lg w-full">
-        <p className="text-gray-500 font-medium">아직 리뷰가 없습니다.</p>
-        <Button variant="primary" className="mt-4 px-8">
-          첫 리뷰 작성하기
-        </Button>
-      </div>
+      <ReviewEmpty
+        onWriteClick={() => {
+          /* 여기에 리뷰 작성 모달을 여는 로직을 연결하세요! */
+          console.log('리뷰 작성 모달 오픈');
+        }}
+      />
     );
   }
 

--- a/components/wine/detail/WineDetailLayout.tsx
+++ b/components/wine/detail/WineDetailLayout.tsx
@@ -11,7 +11,7 @@ interface WineDetailLayoutProps {
 
 export default function WineDetailLayout({ wine, user }: WineDetailLayoutProps) {
   return (
-    <Container>
+    <Container className="pb-16 lg:pb-20">
       <WineProfile wine={wine} />
       <ReviewSection wine={wine} myId={user?.id ?? 0} />
     </Container>

--- a/components/wine/detail/WineDetailLayout.tsx
+++ b/components/wine/detail/WineDetailLayout.tsx
@@ -1,12 +1,19 @@
 import Container from '@/components/common/layout/Container';
 import WineProfile from '@/components/wine/detail/WineProfile';
 import ReviewSection from '@/components/wine/detail/ReviewSection';
+import { ApiUser } from '@/lib/api/user/user.types';
+import { GetWineDetailResponse } from '@/lib/api/wine/wine.types';
 
-export default function WineDetailLayout() {
+interface WineDetailLayoutProps {
+  wine: GetWineDetailResponse;
+  user: ApiUser | null;
+}
+
+export default function WineDetailLayout({ wine, user }: WineDetailLayoutProps) {
   return (
     <Container>
-      <WineProfile />
-      <ReviewSection />
+      <WineProfile wine={wine} />
+      <ReviewSection wine={wine} myId={user?.id ?? 0} />
     </Container>
   );
 }

--- a/components/wine/detail/WineDetailLayout.tsx
+++ b/components/wine/detail/WineDetailLayout.tsx
@@ -10,9 +10,10 @@ interface WineDetailLayoutProps {
 }
 
 export default function WineDetailLayout({ wine, user }: WineDetailLayoutProps) {
+  const hasReviews = wine.reviewCount > 0;
   return (
     <Container className="pb-16 lg:pb-20">
-      <WineProfile wine={wine} />
+      {hasReviews && <WineProfile wine={wine} />}
       <ReviewSection wine={wine} myId={user?.id ?? 0} />
     </Container>
   );

--- a/components/wine/detail/WineProfile.tsx
+++ b/components/wine/detail/WineProfile.tsx
@@ -1,24 +1,17 @@
-import TasteItem, { TASTES, Taste } from '@/components/common/ui/TasteItem';
-import { MOCK_WINE_DETAIL } from '@/mock/wineDetail.mock';
+import TasteItem, { TASTES } from '@/components/common/ui/TasteItem';
+import { GetWineDetailResponse } from '@/lib/api/wine/wine.types';
+import { getTasteValueByLabel } from '@/utils/tasteValue';
+import { calculateAveragePalate } from '@/utils/winePalate';
 
-// 임시! 데이터 연결시 따로 파일분리 예정
-const getTasteValue = (tasteName: Taste, data: typeof MOCK_WINE_DETAIL.tastes) => {
-  switch (tasteName) {
-    case '바디감':
-      return data.body;
-    case '탄닌':
-      return data.tannin;
-    case '당도':
-      return data.sweetness;
-    case '산미':
-      return data.acidity;
-    default:
-      return 0;
-  }
-};
+interface WineProfileProps {
+  wine: GetWineDetailResponse;
+}
+export default function WineProfile({ wine }: WineProfileProps) {
+  const { reviewCount } = wine;
+  const averagePalate = calculateAveragePalate(wine.reviews);
 
-export default function WineProfile() {
-  const { tastes: wineTastes, reviewCount } = MOCK_WINE_DETAIL;
+  // 임시로 보여줄 향기 리스트
+  const TEMP_AROMAS = ['과일', '오크', '바닐라'];
   return (
     <section className="flex flex-col lg:flex-row gap-y-12 lg:gap-y-0 lg:gap-x-20 py-6 md:py-10 lg:py-20 border-b border-border">
       <div className="flex-1">
@@ -32,7 +25,7 @@ export default function WineProfile() {
               <TasteItem
                 key={`detail-${name}`}
                 taste={name}
-                value={getTasteValue(name, wineTastes)}
+                value={getTasteValueByLabel(averagePalate, name)}
                 showDivider
               />
             ))}
@@ -45,6 +38,18 @@ export default function WineProfile() {
           <div className="flex flex-col lg:flex-row lg:justify-between lg:items-end w-full mb-4 md:mb-0 lg:mb-6">
             <h3 className="text-2xl font-bold">어떤 향이 나나요?</h3>
             <span className="text-sm text-muted-foreground mt-1">({reviewCount}명 참여)</span>
+          </div>
+
+          <div className="flex flex-wrap gap-2 mt-4">
+            {TEMP_AROMAS.map(item => (
+              <span
+                key={item}
+                className="inline-flex items-center px-4 py-2 rounded-full bg-gray-100 text-gray-700 text-sm border border-gray-200"
+              >
+                {item}
+              </span>
+            ))}
+            {/* ui작업중  */}
           </div>
         </div>
       </div>

--- a/hooks/useReviewStats.ts
+++ b/hooks/useReviewStats.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
-import { Review } from '@/types/domain/review';
+import { ApiWineReview } from '@/lib/api/wine/wine.types';
 import { calculateAverage, calculateDistribution } from '@/utils/reviewStats';
 
-export const useReviewStats = (reviews: Review[] = []) => {
+export const useReviewStats = (reviews: ApiWineReview[] = []) => {
   return useMemo(() => {
     return {
       totalReviews: reviews.length,

--- a/lib/api/wine/wine.ts
+++ b/lib/api/wine/wine.ts
@@ -18,8 +18,13 @@ export function getWines(query: GetWinesQuery) {
   });
 }
 
-export function getWine(id: number) {
-  return fetcher<GetWineDetailResponse>(`/wines/${id}`, { method: 'GET' });
+export function getWine(id: number, accessToken: string) {
+  return fetcher<GetWineDetailResponse>(`/wines/${id}`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
 }
 
 export function getRecommendedWines(limit: number) {

--- a/lib/api/wine/wine.types.ts
+++ b/lib/api/wine/wine.types.ts
@@ -5,20 +5,16 @@ import { QueryParams } from '@/lib/fetcher';
 
 export type WineUser = ApiUser;
 
-export type ApiRecentReview = Pick<
-  ApiReview,
-  | 'id'
-  | 'content'
-  | 'aroma'
-  | 'rating'
-  | 'createdAt'
-  | 'updatedAt'
-  | 'user'
-  | 'lightBold'
-  | 'smoothTannic'
-  | 'drySweet'
-  | 'softAcidic'
->;
+export interface TasteData {
+  lightBold: number;
+  smoothTannic: number;
+  drySweet: number;
+  softAcidic: number;
+}
+
+export type ApiWineReview = Omit<ApiReview, 'wineId' | 'teamId'> & TasteData;
+
+export type ApiRecentReview = ApiWineReview;
 
 export interface ApiWine {
   id: number;
@@ -31,10 +27,6 @@ export interface ApiWine {
   reviewCount: number;
   userId: number;
   recentReview?: ApiRecentReview;
-  lightBold: number;
-  smoothTannic: number;
-  drySweet: number;
-  softAcidic: number;
 }
 
 export type WineListItem = ApiWine;
@@ -57,25 +49,16 @@ export interface GetWinesResponse {
 
 export type GetRecommendedWinesResponse = WineListItem[];
 
-export type ApiWineReview = Omit<ApiReview, 'wineId' | 'teamId'>;
-
 export interface GetWineDetailResponse extends ApiWine {
   reviews: ApiWineReview[];
   avgRatings: Record<string, number>;
 }
 
 export type CreateWineRequest = Pick<ApiWine, 'name' | 'region' | 'image' | 'price' | 'type'>;
-
 export type UpdateWineRequest = Partial<
   Pick<ApiWine, 'name' | 'region' | 'image' | 'price' | 'type' | 'avgRating'>
 >;
 
 export type CreateWineResponse = ApiWine;
 export type UpdateWineResponse = ApiWine;
-
 export type DeleteWineResponse = Pick<ApiWine, 'id'>;
-
-export interface GetWineDetailResponse extends ApiWine {
-  reviews: ApiWineReview[];
-  avgRatings: Record<string, number>;
-}

--- a/lib/api/wine/wine.types.ts
+++ b/lib/api/wine/wine.types.ts
@@ -7,7 +7,17 @@ export type WineUser = ApiUser;
 
 export type ApiRecentReview = Pick<
   ApiReview,
-  'id' | 'content' | 'aroma' | 'rating' | 'createdAt' | 'updatedAt' | 'user'
+  | 'id'
+  | 'content'
+  | 'aroma'
+  | 'rating'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'user'
+  | 'lightBold'
+  | 'smoothTannic'
+  | 'drySweet'
+  | 'softAcidic'
 >;
 
 export interface ApiWine {
@@ -21,6 +31,10 @@ export interface ApiWine {
   reviewCount: number;
   userId: number;
   recentReview?: ApiRecentReview;
+  lightBold: number;
+  smoothTannic: number;
+  drySweet: number;
+  softAcidic: number;
 }
 
 export type WineListItem = ApiWine;
@@ -60,3 +74,8 @@ export type CreateWineResponse = ApiWine;
 export type UpdateWineResponse = ApiWine;
 
 export type DeleteWineResponse = Pick<ApiWine, 'id'>;
+
+export interface GetWineDetailResponse extends ApiWine {
+  reviews: ApiWineReview[];
+  avgRatings: Record<string, number>;
+}

--- a/pages/wines/[wineid].tsx
+++ b/pages/wines/[wineid].tsx
@@ -1,11 +1,63 @@
+import { GetServerSideProps } from 'next';
 import HeroSection from '@/components/wine/detail/HeroSection';
 import WineDetailLayout from '@/components/wine/detail/WineDetailLayout';
+import { GetWineDetailResponse } from '@/lib/api/wine/wine.types';
+import { ApiUser } from '@/lib/api/user/user.types';
+import { parseCookie } from '@/lib/auth/cookie';
+import { getWine } from '@/lib/api/wine/wine';
+import { fetcher } from '@/lib/fetcher';
+import { ApiPath } from '@/lib/fetcher.types';
 
-export default function WineDetailPage() {
+interface WineDetailPageProps {
+  wine: GetWineDetailResponse;
+  user: ApiUser;
+}
+
+export default function WineDetailPage({ wine, user }: WineDetailPageProps) {
+  if (!wine) return <div>와인 정보를 불러올 수 없습니다.</div>;
+
   return (
     <main>
-      <HeroSection />
-      <WineDetailLayout />
+      <HeroSection wine={wine} />
+      <WineDetailLayout wine={wine} user={user} />
     </main>
   );
 }
+
+export const getServerSideProps: GetServerSideProps<WineDetailPageProps> = async context => {
+  const { wineid: id } = context.params!;
+  const cookies = parseCookie(context.req.headers.cookie || '');
+  const rawToken = cookies['accessToken'];
+  const accessToken = rawToken && rawToken !== 'undefined' ? rawToken.replace(/"/g, '') : null;
+  if (!accessToken) {
+    return { redirect: { destination: '/login', permanent: false } };
+  }
+
+  try {
+    const [wine, user] = await Promise.all([
+      getWine(Number(id), accessToken),
+      fetcher<ApiUser>(`/users/me` as ApiPath, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      }),
+    ]);
+
+    if (!wine) {
+      return { notFound: true };
+    }
+
+    return { props: { wine, user } };
+  } catch (error: unknown) {
+    let status = 500;
+
+    if (error !== null && typeof error === 'object' && 'status' in error) {
+      status = (error as { status: number }).status;
+    }
+
+    if (status === 401) {
+      return { redirect: { destination: '/login', permanent: false } };
+    }
+
+    console.error(`상세 페이지 로드 실패: ${status}`);
+    return { notFound: true };
+  }
+};

--- a/types/domain/review.ts
+++ b/types/domain/review.ts
@@ -9,10 +9,9 @@ export interface Taste {
 
 export interface UserInReview {
   id: number;
-  name: string;
-  image: string;
+  nickname: string;
+  image: string | null;
 }
-
 export interface WineInReview {
   id: number;
   name: string;
@@ -24,10 +23,15 @@ export interface Review {
   id: number;
   rating: number;
   content: string;
-  createdAt: Date;
+  createdAt: string;
+  updatedAt: string;
   aroma: AromaType[];
-  tastes: Taste;
-  wine?: WineInReview;
+  lightBold: number;
+  smoothTannic: number;
+  drySweet: number;
+  softAcidic: number;
   user: UserInReview;
-  isLiked?: boolean;
+  wineId: number;
+  isLiked: boolean;
+  teamId: string;
 }

--- a/utils/reviewStats.ts
+++ b/utils/reviewStats.ts
@@ -1,17 +1,15 @@
-import { Review } from '@/types/domain/review';
-
 export interface ReviewStatItem {
   star: number;
   ratio: number;
 }
 
-export const calculateAverage = (reviews: Review[]): number => {
+export const calculateAverage = (reviews: { rating: number }[]) => {
   if (reviews.length === 0) return 0;
   const total = reviews.reduce((acc, curr) => acc + curr.rating, 0);
   return total / reviews.length;
 };
 
-export const calculateDistribution = (reviews: Review[]): ReviewStatItem[] => {
+export const calculateDistribution = (reviews: { rating: number }[]) => {
   const total = reviews.length;
   return [5, 4, 3, 2, 1].map(star => {
     const count = reviews.filter(r => r.rating === star).length;

--- a/utils/tasteValue.ts
+++ b/utils/tasteValue.ts
@@ -1,32 +1,16 @@
 import { Taste as TasteLabel } from '@/components/common/ui/TasteItem';
+import { TasteData } from '@/lib/api/wine/wine.types';
 
-interface ReviewTasteData {
-  lightBold: number;
-  smoothTannic: number;
-  drySweet: number;
-  softAcidic: number;
-}
-
-interface WineTasteData {
-  body: number;
-  tannin: number;
-  sweetness: number;
-  acidity: number;
-}
-
-export const getTasteValueByLabel = (
-  data: Partial<ReviewTasteData & WineTasteData>,
-  label: TasteLabel
-): number => {
+export const getTasteValueByLabel = (data: Partial<TasteData>, label: TasteLabel): number => {
   switch (label) {
     case '바디감':
-      return data.lightBold ?? data.body ?? 0;
+      return data.lightBold ?? 0;
     case '탄닌':
-      return data.smoothTannic ?? data.tannin ?? 0;
+      return data.smoothTannic ?? 0;
     case '당도':
-      return data.drySweet ?? data.sweetness ?? 0;
+      return data.drySweet ?? 0;
     case '산미':
-      return data.softAcidic ?? data.acidity ?? 0;
+      return data.softAcidic ?? 0;
     default:
       return 0;
   }

--- a/utils/tasteValue.ts
+++ b/utils/tasteValue.ts
@@ -1,0 +1,33 @@
+import { Taste as TasteLabel } from '@/components/common/ui/TasteItem';
+
+interface ReviewTasteData {
+  lightBold: number;
+  smoothTannic: number;
+  drySweet: number;
+  softAcidic: number;
+}
+
+interface WineTasteData {
+  body: number;
+  tannin: number;
+  sweetness: number;
+  acidity: number;
+}
+
+export const getTasteValueByLabel = (
+  data: Partial<ReviewTasteData & WineTasteData>,
+  label: TasteLabel
+): number => {
+  switch (label) {
+    case '바디감':
+      return data.lightBold ?? data.body ?? 0;
+    case '탄닌':
+      return data.smoothTannic ?? data.tannin ?? 0;
+    case '당도':
+      return data.drySweet ?? data.sweetness ?? 0;
+    case '산미':
+      return data.softAcidic ?? data.acidity ?? 0;
+    default:
+      return 0;
+  }
+};

--- a/utils/winePalate.ts
+++ b/utils/winePalate.ts
@@ -1,0 +1,28 @@
+import { Review } from '@/types/domain/review';
+
+type TasteFields = Pick<Review, 'lightBold' | 'smoothTannic' | 'drySweet' | 'softAcidic'>;
+
+export const calculateAveragePalate = (reviews: TasteFields[]): TasteFields => {
+  if (!reviews || reviews.length === 0) {
+    return { lightBold: 0, smoothTannic: 0, drySweet: 0, softAcidic: 0 };
+  }
+
+  const totals = reviews.reduce(
+    (acc, rev) => ({
+      lightBold: acc.lightBold + (rev.lightBold || 0),
+      smoothTannic: acc.smoothTannic + (rev.smoothTannic || 0),
+      drySweet: acc.drySweet + (rev.drySweet || 0),
+      softAcidic: acc.softAcidic + (rev.softAcidic || 0),
+    }),
+    { lightBold: 0, smoothTannic: 0, drySweet: 0, softAcidic: 0 }
+  );
+
+  const count = reviews.length;
+
+  return {
+    lightBold: totals.lightBold / count,
+    smoothTannic: totals.smoothTannic / count,
+    drySweet: totals.drySweet / count,
+    softAcidic: totals.softAcidic / count,
+  };
+};


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

## 같이 고민해 주세요 (리뷰 포인트)

- 부분부분 수정이 많았습니다 !  여러번 체크는 했지만 잘 적용한건지 같이 잘 체크 부탁드려요 ㅠㅠ 
-  서버 API가 와인 상세 데이터(body, tannin)와 리뷰 데이터(lightBold, smoothTannic)에서 서로 다른 필드명을 사용하고 있었습니다. 이를 공통으로 사용할 수 있도록 교차 정의하고 유틸리티 함수를 구현하면서 수정이 많았습니다

더 작업이 필요한 부분
- 상세페이지 상단, 향 적용 (api연동을 위해 임시로 작업해둠)
- 좋아요 활성화
- 모달 




## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #173)

## 테스트 결과 
<img width="1323" height="915" alt="스크린샷 2026-02-21 오전 12 15 34" src="https://github.com/user-attachments/assets/dcf474b2-31b3-47ba-96e4-ac1c6bb62453" />
<img width="1364" height="798" alt="스크린샷 2026-02-21 오전 12 15 40" src="https://github.com/user-attachments/assets/a2723468-b937-4e99-846c-71612a1d1774" />
<img width="390" height="720" alt="스크린샷 2026-02-21 오전 12 16 00" src="https://github.com/user-attachments/assets/0a439a0b-e6de-41e5-b5b3-236bd31e60d0" />
<img width="1259" height="493" alt="스크린샷 2026-02-21 오전 8 00 35" src="https://github.com/user-attachments/assets/2b5f15d3-86bb-4f9c-aed5-514e0cae9354" />
<img width="443" height="444" alt="스크린샷 2026-02-21 오전 8 00 45" src="https://github.com/user-attachments/assets/fa4380ad-c36a-4ca4-93ba-79013aea670b" />

<img width="683" height="414" alt="스크린샷 2026-02-21 오후 9 14 05" src="https://github.com/user-attachments/assets/369d86fe-2228-40d9-8904-ae760609cacf" />



작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)
