### PR TITLE
feat: AlertDialog, Toast 공통 UI 컴포넌트 추가

### DIFF
--- a/components/common/ui/AlertDialog/AlertDialog.tsx
+++ b/components/common/ui/AlertDialog/AlertDialog.tsx
@@ -1,0 +1,163 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import Button from '../Button';
+
+import type { ReactPortal, PropsWithChildren, MouseEvent, SetStateAction } from 'react';
+import type {
+  AlertDialogContextValue,
+  AlertDialogProps,
+  AlertDialogTriggerProps,
+  AlertDialogContentProps,
+  AlertDialogActionProps,
+} from './types';
+
+import { cn } from '@/utils/cn';
+
+const AlertDialogContext = createContext<AlertDialogContextValue | null>(null);
+
+const useAlertDialog = () => {
+  const ctx = useContext(AlertDialogContext);
+  if (!ctx) {
+    throw new Error('AlertDialog 컴포넌트 내부에서만 사용');
+  }
+  return ctx;
+};
+
+const useAlertDialogState = () => {
+  const [open, setOpen] = useState(false);
+
+  const onOpen = () => setOpen(true);
+  const onClose = () => setOpen(false);
+
+  return { open, onOpenChange: setOpen, onOpen, onClose };
+};
+
+function AlertDialog({ children, open: controlledOpen, onOpenChange }: AlertDialogProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+
+  const isOpen = controlledOpen !== undefined ? controlledOpen : uncontrolledOpen;
+
+  const handleOpenChange = (value: SetStateAction<boolean>) => {
+    if (controlledOpen !== undefined) {
+      onOpenChange?.(value);
+    } else {
+      setUncontrolledOpen(value);
+    }
+  };
+
+  const value = {
+    open: isOpen,
+    setOpen: handleOpenChange,
+  };
+
+  return <AlertDialogContext.Provider value={value}>{children}</AlertDialogContext.Provider>;
+}
+
+function AlertDialogTrigger({ children, onClick }: AlertDialogTriggerProps) {
+  const { setOpen } = useAlertDialog();
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    onClick?.(e);
+    setOpen(true);
+  };
+
+  return <Button onClick={handleClick}>{children}</Button>;
+}
+
+function AlertDialogPortal({ children }: PropsWithChildren): ReactPortal | null {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  return createPortal(children, document.body);
+}
+
+function AlertDialogOverlay() {
+  return <div className="fixed inset-0 isolate z-50 bg-black/50" />;
+}
+
+function AlertDialogContent({ children, className }: AlertDialogContentProps) {
+  const { open } = useAlertDialog();
+  if (!open) return null;
+
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <div
+        className={cn(
+          'fixed z-50 bg-white shadow-lg transition-all flex flex-col',
+          'left-1/2 top-1/2 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-[12px]',
+          className
+        )}
+      >
+        {children}
+      </div>
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({ children, className }: AlertDialogContentProps) {
+  return <div className={cn('flex flex-col gap-2 p-6', className)}>{children}</div>;
+}
+
+function AlertDialogFooter({ children, className }: AlertDialogContentProps) {
+  return (
+    <div className={cn('flex flex-col-reverse gap-2 p-6 sm:flex-row sm:justify-end', className)}>
+      {children}
+    </div>
+  );
+}
+
+function AlertDialogTitle({ children, className }: AlertDialogContentProps) {
+  return <h2 className={cn('text-lg font-semibold', className)}>{children}</h2>;
+}
+
+function AlertDialogDescription({ children, className }: AlertDialogContentProps) {
+  return <p className={cn('text-sm text-gray-600', className)}>{children}</p>;
+}
+
+function AlertDialogCancel({ children, className }: AlertDialogContentProps) {
+  const { setOpen } = useAlertDialog();
+  return (
+    <Button className={cn('', className)} onClick={() => setOpen(false)}>
+      {children}
+    </Button>
+  );
+}
+
+function AlertDialogAction({ children, className, onClick }: AlertDialogActionProps) {
+  const { setOpen } = useAlertDialog();
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    onClick?.(e);
+    setOpen(false);
+  };
+
+  return (
+    <Button className={cn('', className)} onClick={handleClick}>
+      {children}
+    </Button>
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogCancel,
+  AlertDialogAction,
+  useAlertDialogState,
+  useAlertDialog,
+};

--- a/components/common/ui/AlertDialog/AlertDialog.tsx
+++ b/components/common/ui/AlertDialog/AlertDialog.tsx
@@ -122,10 +122,16 @@ function AlertDialogDescription({ children, className }: AlertDialogContentProps
   return <p className={cn('text-sm text-gray-600', className)}>{children}</p>;
 }
 
-function AlertDialogCancel({ children, className }: AlertDialogContentProps) {
+function AlertDialogCancel({ children, className, onClick }: AlertDialogContentProps) {
   const { setOpen } = useAlertDialog();
   return (
-    <Button className={cn('', className)} onClick={() => setOpen(false)}>
+    <Button
+      className={cn('', className)}
+      onClick={e => {
+        onClick?.(e);
+        setOpen(false);
+      }}
+    >
       {children}
     </Button>
   );

--- a/components/common/ui/AlertDialog/index.ts
+++ b/components/common/ui/AlertDialog/index.ts
@@ -1,0 +1,14 @@
+export {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogCancel,
+  AlertDialogAction,
+  useAlertDialogState,
+} from './AlertDialog';

--- a/components/common/ui/AlertDialog/types.ts
+++ b/components/common/ui/AlertDialog/types.ts
@@ -19,6 +19,7 @@ export interface AlertDialogTriggerProps {
 export interface AlertDialogContentProps {
   children: ReactNode;
   className?: string;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
 export interface AlertDialogActionProps {

--- a/components/common/ui/AlertDialog/types.ts
+++ b/components/common/ui/AlertDialog/types.ts
@@ -1,0 +1,28 @@
+import type { ReactNode, Dispatch, SetStateAction, MouseEventHandler } from 'react';
+
+export interface AlertDialogContextValue {
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+export interface AlertDialogProps {
+  children: ReactNode;
+  open?: boolean;
+  onOpenChange?: Dispatch<SetStateAction<boolean>>;
+}
+
+export interface AlertDialogTriggerProps {
+  children: ReactNode;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+}
+
+export interface AlertDialogContentProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export interface AlertDialogActionProps {
+  children: ReactNode;
+  className?: string;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+}

--- a/components/common/ui/Toast/Toast.tsx
+++ b/components/common/ui/Toast/Toast.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { subscribe, getSnapshot, dismiss } from './toastStore';
+import { cn } from '@/utils/cn';
+
+import type { ToastItem } from './types';
+
+function ToastItemComponent({ id, title, message, variant }: ToastItem) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'relative w-full min-w-[280px] max-w-sm rounded px-4 py-3 shadow-lg',
+        'bg-zinc-900 text-white',
+        variant === 'error' && 'border border-red-500',
+        variant === 'success' && 'border border-green-500',
+        variant === 'info' && 'border border-blue-500',
+        variant === 'default' && 'border border-zinc-700'
+      )}
+    >
+      {title && <p className="text-sm font-semibold mb-0.5">{title}</p>}
+      <p className={cn('text-sm', title ? 'text-zinc-400' : 'text-white')}>{message}</p>
+
+      <button
+        onClick={() => dismiss(id)}
+        aria-label="닫기"
+        className="absolute right-3 top-2.5 text-zinc-500 hover:text-white transition-colors text-xs"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+
+export function Toaster() {
+  const [toasts, setToasts] = useState<ToastItem[]>(getSnapshot);
+
+  useEffect(() => {
+    const unsubscribe = subscribe(() => {
+      setToasts(getSnapshot());
+    });
+    return unsubscribe;
+  }, []);
+
+  if (toasts.length === 0) return null;
+
+  return createPortal(
+    <div className="fixed bottom-4 right-4 z-[9999] flex flex-col gap-2 items-end">
+      {toasts.map(toast => (
+        <ToastItemComponent key={toast.id} {...toast} />
+      ))}
+    </div>,
+    document.body
+  );
+}

--- a/components/common/ui/Toast/index.ts
+++ b/components/common/ui/Toast/index.ts
@@ -1,0 +1,2 @@
+export { Toaster } from './Toast';
+export { toast, dismiss } from './toastStore';

--- a/components/common/ui/Toast/toastStore.ts
+++ b/components/common/ui/Toast/toastStore.ts
@@ -1,0 +1,48 @@
+import type { ToastItem, ToastOptions, ToastVariant } from './types';
+
+let toasts: ToastItem[] = [];
+let nextId = 0;
+
+const listeners = new Set<() => void>();
+
+const MAX_TOASTS = 5;
+export const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const getSnapshot = (): ToastItem[] => toasts;
+
+const notify = () => listeners.forEach(listener => listener());
+export const dismiss = (id: number) => {
+  toasts = toasts.filter(t => t.id !== id);
+  notify();
+};
+
+const addToast = (message: string, options?: ToastOptions) => {
+  const id = nextId++;
+  const variant: ToastVariant = options?.variant ?? 'default';
+  const duration = options?.duration ?? 3000;
+  const title = options?.title;
+
+  const newToast: ToastItem = { id, title, message, variant, duration };
+
+  const next = [...toasts, newToast];
+  toasts = next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next;
+
+  notify();
+  setTimeout(() => dismiss(id), duration);
+};
+
+export const toast = (message: string, options?: ToastOptions) => addToast(message, options);
+
+toast.success = (message: string, options?: Omit<ToastOptions, 'variant'>) =>
+  addToast(message, { ...options, variant: 'success' });
+
+toast.error = (message: string, options?: Omit<ToastOptions, 'variant'>) =>
+  addToast(message, { ...options, variant: 'error' });
+
+toast.info = (message: string, options?: Omit<ToastOptions, 'variant'>) =>
+  addToast(message, { ...options, variant: 'info' });

--- a/components/common/ui/Toast/types.ts
+++ b/components/common/ui/Toast/types.ts
@@ -1,0 +1,15 @@
+export type ToastVariant = 'default' | 'success' | 'error' | 'info';
+
+export interface ToastItem {
+  id: number;
+  title?: string;
+  message: string;
+  variant: ToastVariant;
+  duration: number;
+}
+
+export interface ToastOptions {
+  title?: string;
+  variant?: ToastVariant;
+  duration?: number;
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,13 @@
 import '@/styles/globals.css';
 import type { AppProps } from 'next/app';
 import { AuthProvider } from '@/providers/Auth/AuthProvider';
+import { Toaster } from '@/components/common/ui/Toast';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <AuthProvider>
       <Component {...pageProps} />
+      <Toaster />
     </AuthProvider>
   );
 }


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- AlertDialog (confirm대체) 컴포넌트 추가
- Toast 컴포넌트 추가

## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.
(예: 이 로직을 훅으로 분리하는 게 맞는지 확신이 안 섭니다. / A방식과 B방식 중 성능 때문에 A를 택했는데 의견 궁금합니다.)

- AlertDiglog 는 Dialog 컴포넌트랑 다른점은 거의 없긴합니다만.. Dimmed 영역 클릭시 닫히는지 안닫히는지 해당 차이만 존재하고 있습니다. 
  - Dialog 컴포넌트에 ESC 클릭시 닫히도록 추가하면 둘의 차이가 조금이라도 더 있지만.. 아직 추가는 안했습니다.  이 부분을 추가해서 서로 다른 컴포넌트라는걸 조금 더 명확하게 처리할지 고민입니다.
 
- Toast 컴포넌트는 모듈 패턴과 구독자 패턴을 이용하여 useEffect 로 모듈 스토어를 구독, 상태 변경시 state 변경으로 리렌더링 하도록 처리했습니다.
  -  dismiss 함수는 즉시 배열에서 값을 삭제하고 있어서 Toast가 뚝뚝 끊기는 느낌으로 제거되고 있습니다. 이 부분은 더 개선할 수 있지만.. 현재는 단순하게 처리하였습니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #178 )

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)

<img width="298" height="303" alt="image" src="https://github.com/user-attachments/assets/ed9926d8-c0dc-443a-99ac-acf0b6454e38" />

<img width="502" height="271" alt="image" src="https://github.com/user-attachments/assets/9f65fef2-f5c0-473c-a85f-2b59ec4f9194" />