### PR TITLE
feat: myprofile API 연동 작업

### DIFF
--- a/components/myprofile/AuthGuard.tsx
+++ b/components/myprofile/AuthGuard.tsx
@@ -1,0 +1,28 @@
+import { useAuth } from '@/providers/Auth/AuthProvider';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+interface AuthGuardProps {
+  children: React.ReactNode;
+}
+
+export default function AuthGuard({ children }: AuthGuardProps) {
+  const { user, isLoading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && !user) {
+      router.replace('/auth/signin');
+    }
+  }, [isLoading, user, router]);
+
+  if (isLoading) {
+    return <div>인증 확인 중...</div>;
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/components/myprofile/MyProfileContainer.tsx
+++ b/components/myprofile/MyProfileContainer.tsx
@@ -1,0 +1,47 @@
+import { useAuth } from '@/providers/Auth/AuthProvider';
+import MyProfilePage from './MyProfilePage';
+import { useMyReviews } from '@/hooks/myprofile/useMyReviews';
+import { useMyWines } from '@/hooks/myprofile/useMyWines';
+import { useUpdateProfile } from '@/hooks/myprofile/useUpdateProfile';
+
+interface MyProfileErrors {
+  profile?: string | null;
+  reviews?: string | null;
+  wines?: string | null;
+}
+
+export default function MyProfileContainer() {
+  const { user } = useAuth();
+
+  const reviewsState = useMyReviews();
+  const winesState = useMyWines();
+  const profileState = useUpdateProfile();
+
+  const errors: MyProfileErrors = {
+    profile: profileState.error,
+    reviews: reviewsState.error,
+    wines: winesState.error,
+  };
+
+  if (!user) return null;
+
+  const profileUser = {
+    nickname: user.nickname,
+    image: user.image,
+  };
+  return (
+    <MyProfilePage
+      key={`${user.nickname}-${user.image}`}
+      user={profileUser}
+      reviews={reviewsState.reviews}
+      wines={winesState.wines}
+      loadingReviews={reviewsState.loading}
+      loadingWines={winesState.loading}
+      onFetchReviews={reviewsState.fetch}
+      onFetchWines={winesState.fetch}
+      onUpdateProfile={profileState.updateProfile}
+      isUpdating={profileState.isUpdating}
+      error={errors}
+    />
+  );
+}

--- a/components/myprofile/MyProfilePage.tsx
+++ b/components/myprofile/MyProfilePage.tsx
@@ -1,38 +1,94 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ProfileSidebar from './ProfileSidebar';
 import MyReviewsPanel from './MyReviewsPanel';
-import { mockMyReviews } from '@/mock/review.my.mock';
 import MyWinesPanel from './MyWinesPanel';
-import { mockWineData } from '@/mock/wine.mock';
 import MyProfileLayout from './MyProfileLayout';
 import MyProfileTabs from './MyProfileTabs';
+import { ApiReview } from '@/lib/api/review/review.types';
+import { WineListItem } from '@/lib/api/wine/wine.types';
+import { ApiUser } from '@/lib/api/user/user.types';
 
 type Tab = 'reviews' | 'wines';
 
-const mockUser = {
-  image: null,
-  nickname: '주말와인',
-};
+type UserProfile = Pick<ApiUser, 'image' | 'nickname'>;
 
-export default function MyProfilePage() {
-  const [tab, setTab] = useState<Tab>('wines');
-  const [nickname, setNickname] = useState(mockUser.nickname);
+interface MyProfileErrors {
+  profile?: string | null;
+  reviews?: string | null;
+  wines?: string | null;
+}
+
+interface MyProfilePageProps {
+  user: UserProfile;
+  reviews: ApiReview[];
+  wines: WineListItem[];
+  loadingReviews: boolean;
+  loadingWines: boolean;
+  onFetchReviews: () => void;
+  onFetchWines: () => void;
+  onUpdateProfile: (nickname: string, file?: File | null) => void;
+  isUpdating: boolean;
+  error?: MyProfileErrors;
+}
+
+export default function MyProfilePage({
+  user,
+  reviews,
+  wines,
+  loadingReviews,
+  loadingWines,
+  onFetchReviews,
+  onFetchWines,
+  onUpdateProfile,
+  isUpdating,
+  error,
+}: MyProfilePageProps) {
+  const [tab, setTab] = useState<Tab>('reviews');
+  const [nickname, setNickname] = useState(user.nickname);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+
+  useEffect(() => {
+    if (tab === 'reviews') onFetchReviews();
+    if (tab === 'wines') onFetchWines();
+  }, [tab, onFetchReviews, onFetchWines]);
+
+  const handleSubmit = () => {
+    onUpdateProfile(nickname, imageFile);
+    setImageFile(null);
+  };
 
   return (
     <MyProfileLayout
       sidebar={
         <ProfileSidebar
-          user={mockUser}
+          user={user}
           nickname={nickname}
           onNicknameChange={setNickname}
-          onSubmit={() => console.log('변경할 닉네임:', nickname)} // 임시
+          onImageChange={setImageFile}
+          onSubmit={handleSubmit}
+          isUpdating={isUpdating}
+          error={error?.profile ?? undefined}
         />
       }
       content={
         <>
           <MyProfileTabs value={tab} onChange={setTab} />
-          {tab === 'reviews' && <MyReviewsPanel reviews={mockMyReviews} />}
-          {tab === 'wines' && <MyWinesPanel wines={mockWineData.list} />}
+          {tab === 'reviews' &&
+            (loadingReviews ? (
+              <div>리뷰 불러오는 중...</div>
+            ) : reviews.length === 0 ? (
+              <div>작성한 리뷰가 없습니다.</div>
+            ) : (
+              <MyReviewsPanel reviews={reviews} />
+            ))}
+          {tab === 'wines' &&
+            (loadingWines ? (
+              <div>와인 불러오는 중...</div>
+            ) : wines.length === 0 ? (
+              <div>등록한 와인이 없습니다.</div>
+            ) : (
+              <MyWinesPanel wines={wines} />
+            ))}
         </>
       }
     />

--- a/components/myprofile/MyReviewsPanel.tsx
+++ b/components/myprofile/MyReviewsPanel.tsx
@@ -1,9 +1,9 @@
-import { Review } from '@/types/domain/review';
 import { cn } from '@/utils/cn';
 import MyReviewCard from '../reviewCard/MyReviewCard';
+import { ApiReview } from '@/lib/api/review/review.types';
 
 interface MyReviewsPanelProps {
-  reviews: Review[];
+  reviews: ApiReview[];
   className?: string;
 }
 

--- a/components/myprofile/MyWinesPanel.tsx
+++ b/components/myprofile/MyWinesPanel.tsx
@@ -1,9 +1,9 @@
-import { Wine } from '@/types/domain/wine';
 import { cn } from '@/utils/cn';
 import MyWineCard from '../mywinecard/MyWineCard';
+import { WineListItem } from '@/lib/api/wine/wine.types';
 
 interface MyWinesPanelProps {
-  wines: Wine[];
+  wines: WineListItem[];
   className?: string;
 }
 

--- a/components/myprofile/ProfileSidebar.tsx
+++ b/components/myprofile/ProfileSidebar.tsx
@@ -13,6 +13,8 @@ interface ProfileSidebarProps {
   nickname: string;
   onNicknameChange: (value: string) => void;
   onSubmit: () => void;
+  onImageChange?: (file: File | null) => void;
+  isUpdating?: boolean;
   error?: string;
 }
 
@@ -35,6 +37,8 @@ export default function ProfileSidebar({
   nickname,
   onNicknameChange,
   onSubmit,
+  onImageChange,
+  isUpdating,
   error,
 }: ProfileSidebarProps) {
   const [preview, setPreview] = useState<string | null>(null);
@@ -47,18 +51,19 @@ export default function ProfileSidebar({
   const handleUploadFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+
     setFileError(null);
+
     if (!file.type.startsWith('image/')) {
       setFileError('이미지 파일만 업로드할 수 있습니다.');
-      e.target.value = '';
       return;
     }
 
     if (file.size > MAX_FILE_SIZE) {
       setFileError('파일 크기는 5MB 이하만 가능합니다.');
-      e.target.value = '';
       return;
     }
+    onImageChange?.(file);
     setPreview(prev => {
       if (prev) URL.revokeObjectURL(prev);
       return URL.createObjectURL(file);
@@ -111,10 +116,10 @@ export default function ProfileSidebar({
         <Button
           className="self-end lg:self-center max-w-24.5"
           size="sm"
-          disabled={isDisabled}
+          disabled={isDisabled || isUpdating}
           onClick={onSubmit}
         >
-          변경하기
+          {isUpdating ? '처리 중...' : '변경하기'}
         </Button>
       </div>
     </div>

--- a/components/reviewCard/MyReviewCard.tsx
+++ b/components/reviewCard/MyReviewCard.tsx
@@ -1,30 +1,38 @@
-import { Review } from '@/types/domain/review';
 import ReviewContainer from '../review/ReviewContainer';
 import ReviewRating from '../review/ReviewRating';
 import { formatTimeAgo } from '@/utils/formatTimeAgo';
 import ReviewWineInfo from '../review/ReviewWineInfo';
 import ReviewMenu from '../review/ReviewMenu';
+import TasteItem, { TASTES, Taste as TasteLabel } from '@/components/common/ui/TasteItem';
+import { ApiReview } from '@/lib/api/review/review.types';
 
 interface MyReviewCardProps {
-  review: Review;
+  review: ApiReview;
 }
 
 export default function MyReviewCard({ review }: MyReviewCardProps) {
-  if (!review.wine) return null;
-
   const handleEdit = (reviewId: number) => {
-    console.log('모달');
+    console.log('모달', reviewId);
   };
 
   const handleDelete = (reviewId: number) => {
-    console.log('모달');
+    console.log('모달', reviewId);
   };
 
-  /**
-   * @todo(@jaywai-lee, 26.02.18)
-   * 페이지 레벨 action 연결 전까지 임시 핸들러
-   * merge 후 상위로 lift 예정
-   */
+  const getTasteValue = (tasteName: TasteLabel) => {
+    switch (tasteName) {
+      case '바디감':
+        return review.lightBold;
+      case '탄닌':
+        return review.smoothTannic;
+      case '당도':
+        return review.drySweet;
+      case '산미':
+        return review.softAcidic;
+      default:
+        return 0;
+    }
+  };
 
   return (
     <ReviewContainer
@@ -34,20 +42,25 @@ export default function MyReviewCard({ review }: MyReviewCardProps) {
             <div className="flex gap-2">
               <ReviewRating rating={review.rating} />
               <p className="mr-2">{review.rating}</p>
-              <span className="text-gray-400">{formatTimeAgo(review.createdAt)}</span>
+              <span className="text-gray-400">{formatTimeAgo(new Date(review.createdAt))}</span>
             </div>
             <ReviewMenu reviewId={review.id} onEdit={handleEdit} onDelete={handleDelete} />
           </div>
-          <ReviewWineInfo wine={review.wine} />
+          {review.wine && <ReviewWineInfo wine={review.wine} />}
         </div>
       }
     >
       <div className="mt-4">{review.content}</div>
-      {/**
-       * @todo(@jaywai-lee, 26.02.10)
-       * 애란님 작업 중인 맛 부분 추가 예정
-       */}
-      <div className="h-19 mt-12 bg-gray-100 rounded-md" />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-x-10 gap-y-4 mt-6">
+        {TASTES.map(name => (
+          <TasteItem
+            key={`${review.id}-${name}`}
+            taste={name}
+            value={getTasteValue(name)}
+            variant="default"
+          />
+        ))}
+      </div>
       <div className="h-px mt-10 bg-gray-300" />
     </ReviewContainer>
   );

--- a/hooks/myprofile/useMyReviews.ts
+++ b/hooks/myprofile/useMyReviews.ts
@@ -1,0 +1,27 @@
+import { ApiReview } from '@/lib/api/review/review.types';
+import { getMyReviews } from '@/lib/api/user/user';
+import { useCallback, useState } from 'react';
+
+export function useMyReviews(limit = 10) {
+  const [reviews, setReviews] = useState<ApiReview[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch = useCallback(async () => {
+    if (loading) return;
+    if (reviews.length > 0) return;
+
+    try {
+      setError(null);
+      setLoading(true);
+      const res = await getMyReviews(limit);
+      setReviews(res.list);
+    } catch {
+      setError('리뷰를 불러오지 못했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  }, [loading, reviews.length, limit]);
+
+  return { reviews, loading, error, fetch };
+}

--- a/hooks/myprofile/useMyWines.ts
+++ b/hooks/myprofile/useMyWines.ts
@@ -1,0 +1,27 @@
+import { getMyWines } from '@/lib/api/user/user';
+import { WineListItem } from '@/lib/api/wine/wine.types';
+import { useCallback, useState } from 'react';
+
+export function useMyWines(limit = 10) {
+  const [wines, setWines] = useState<WineListItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch = useCallback(async () => {
+    if (loading) return;
+    if (wines.length > 0) return;
+
+    try {
+      setError(null);
+      setLoading(true);
+      const res = await getMyWines(limit);
+      setWines(res.list);
+    } catch {
+      setError('와인을 불러오지 못했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  }, [loading, wines.length, limit]);
+
+  return { wines, loading, error, fetch };
+}

--- a/hooks/myprofile/useUpdateProfile.ts
+++ b/hooks/myprofile/useUpdateProfile.ts
@@ -1,0 +1,39 @@
+import { uploadImage } from '@/lib/api/infra/image';
+import { updateMe } from '@/lib/api/user/user';
+import { useAuth } from '@/providers/Auth/AuthProvider';
+import { useState } from 'react';
+
+export function useUpdateProfile() {
+  const { user, updateUser } = useAuth();
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateProfile = async (nickname: string, file?: File | null) => {
+    if (!user) return;
+    if (!file && nickname === user.nickname) return;
+
+    try {
+      setIsUpdating(true);
+
+      let imageUrl = user.image;
+
+      if (file) {
+        const res = await uploadImage(file);
+        imageUrl = res.url;
+      }
+
+      const updatedUser = await updateMe({
+        nickname,
+        image: imageUrl,
+      });
+
+      updateUser(updatedUser);
+    } catch {
+      setError('프로필 수정에 실패했습니다.');
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return { updateProfile, isUpdating, error };
+}

--- a/lib/api/review/review.types.ts
+++ b/lib/api/review/review.types.ts
@@ -1,4 +1,5 @@
 import { ApiUser } from '../user/user.types';
+import { ApiWineSummary } from '../wine/wine.types';
 
 export type ReviewUser = ApiUser;
 
@@ -17,6 +18,7 @@ export interface ApiReview {
   isLiked: boolean;
   wineId: number;
   teamId: string;
+  wine?: ApiWineSummary;
 }
 
 export interface CreateReviewRequest {

--- a/lib/api/user/user.ts
+++ b/lib/api/user/user.ts
@@ -20,14 +20,22 @@ export function updateMe(body: UpdateMeRequest) {
   });
 }
 
-export function getMyReviews() {
+export function getMyReviews(limit: number = 10, cursor?: number) {
   return fetcher<GetMyReviewsResponse>('/users/me/reviews', {
     method: 'GET',
+    query: {
+      limit,
+      cursor,
+    },
   });
 }
 
-export function getMyWines() {
+export function getMyWines(limit: number = 10, cursor?: number) {
   return fetcher<GetMyWinesResponse>('/users/me/wines', {
     method: 'GET',
+    query: {
+      limit,
+      cursor,
+    },
   });
 }

--- a/lib/api/user/user.types.ts
+++ b/lib/api/user/user.types.ts
@@ -10,6 +10,14 @@ export type UpdateMeRequest = Partial<Pick<ApiUser, 'nickname' | 'image'>>;
 
 export type UpdateMeResponse = ApiUser;
 
-export type GetMyReviewsResponse = ApiReview[];
+export interface GetMyReviewsResponse {
+  list: ApiReview[];
+  totalCount: number;
+  nextCursor: number | null;
+}
 
-export type GetMyWinesResponse = WineListItem[];
+export interface GetMyWinesResponse {
+  list: WineListItem[];
+  totalCount: number;
+  nextCursor: number | null;
+}

--- a/lib/api/wine/wine.types.ts
+++ b/lib/api/wine/wine.types.ts
@@ -23,6 +23,8 @@ export interface ApiWine {
   recentReview?: ApiRecentReview;
 }
 
+export type ApiWineSummary = Omit<ApiWine, 'reviewCount' | 'userId' | 'recentReview'>;
+
 export type WineListItem = ApiWine;
 
 export interface GetWinesQuery extends QueryParams {

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,11 @@ const nextConfig: NextConfig = {
         hostname: 'i.ifh.cc',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
+        pathname: '/**',
+      },
     ],
   },
 };

--- a/pages/myprofile/index.tsx
+++ b/pages/myprofile/index.tsx
@@ -1,15 +1,16 @@
 import Container from '@/components/common/layout/Container';
 import Gnb from '@/components/common/layout/Gnb';
-import MyProfilePage from '@/components/myprofile/MyProfilePage';
+import AuthGuard from '@/components/myprofile/AuthGuard';
+import MyProfileContainer from '@/components/myprofile/MyProfileContainer';
 
 export default function MyPage() {
   return (
     <>
       <Gnb />
       <Container>
-        <div>
-          <MyProfilePage />
-        </div>
+        <AuthGuard>
+          <MyProfileContainer />
+        </AuthGuard>
       </Container>
     </>
   );


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- myprofile page API 연동 작업 진행

## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.
(예: 이 로직을 훅으로 분리하는 게 맞는지 확신이 안 섭니다. / A방식과 B방식 중 성능 때문에 A를 택했는데 의견 궁금합니다.)

- myprofile page API 연동 작업을 진행했고, mock data를 제거하고 서버 데이터로 적용 확인 했습니다.
- swagger response body와 실제로 넘어오는 데이터가 달라 type 쪽 수정이 있어서 file change가 좀 많습니다..
- profile 부분은 list page modal merge되면 imagepicker을 사용한 형태로 변경 될 예정입니다.
- 임시로 넣어놓은 문구들이 많습니다. 마지막 단계에서 스켈레톤과 토스트, 스피너로 교체 될 예정입니다.
- sprint-fe-project.s3.ap-northeast-2.amazonaws.com를 remotePatterns에 추가 했습니다. 서버에서 반환하는 이미지 url의 호스트 도메인입니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
Closes #171 

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)

<img width="1220" height="750" alt="image" src="https://github.com/user-attachments/assets/29ed6689-ae62-4847-a498-c1bd131a9d85" />

<img width="1411" height="871" alt="image" src="https://github.com/user-attachments/assets/b80dd2f1-8c40-4504-aa2e-6e42233462e5" />
