### PR TITLE
feat: auth page toast 메시지 추가

### DIFF
--- a/hooks/useForm/index.ts
+++ b/hooks/useForm/index.ts
@@ -1,2 +1,2 @@
 export { useForm } from './useForm';
-export type { useFormProps, RegisterOptions, FormMode, Field } from './types';
+export type { useFormProps, RegisterOptions, FormMode, Field, FieldErrors } from './types';

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,11 @@ const nextConfig: NextConfig = {
         hostname: 'i.ifh.cc',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
+        pathname: '/**',
+      },
     ],
   },
 };

--- a/pages/api/proxy/auth/signup.ts
+++ b/pages/api/proxy/auth/signup.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { AuthResponse, SignUpCredentials, User } from '@/types/auth/auth';
+import { AUTH_COOKIES } from '@/lib/auth/cookie';
 
 const BASE_URL = process.env.API_URL;
 const ALLOWED_METHODS = ['POST'];
@@ -34,6 +35,11 @@ export default async function handler(
     }
 
     const data: AuthResponse = await response.json();
+
+    res.setHeader('Set-Cookie', [
+      AUTH_COOKIES.accessToken(data.accessToken),
+      AUTH_COOKIES.refreshToken(data.refreshToken),
+    ]);
 
     return res.status(201).json({
       id: data.user.id,

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -3,6 +3,7 @@ import FormField from '@/components/common/form/FormField';
 import Button from '@/components/common/ui/Button';
 import Link from 'next/link';
 import { useForm } from '@/hooks/useForm/useForm';
+import type { FieldErrors } from '@/hooks/useForm';
 
 import { useRouter } from 'next/router';
 import { useAuth } from '@/providers/Auth/AuthProvider';
@@ -16,7 +17,7 @@ type SignInValues = {
 export default function SignIn() {
   const router = useRouter();
   const { login } = useAuth();
-  const { register, handleSubmit, errors } = useForm<SignInValues>({ mode: 'onSubmit' });
+  const { register, handleSubmit, errors, getValues } = useForm<SignInValues>({ mode: 'onSubmit' });
 
   const valid = async (data: SignInValues) => {
     try {
@@ -37,9 +38,17 @@ export default function SignIn() {
     }
   };
 
+  const Invalid = (errors: FieldErrors<SignInValues>) => {
+    const firstError = Object.values(errors)[0];
+    if (!firstError) return;
+    toast.error(firstError, {
+      title: '로그인 실패',
+    });
+  };
+
   return (
     <AuthLayout>
-      <form className="flex flex-col" onSubmit={handleSubmit(valid)}>
+      <form className="flex flex-col" onSubmit={handleSubmit(valid, Invalid)}>
         <div className="flex flex-col gap-6 mb-10">
           <FormField
             id="email"

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -3,10 +3,10 @@ import FormField from '@/components/common/form/FormField';
 import Button from '@/components/common/ui/Button';
 import Link from 'next/link';
 import { useForm } from '@/hooks/useForm/useForm';
-import type { FieldErrors } from '@/hooks/useForm/types';
 
 import { useRouter } from 'next/router';
 import { useAuth } from '@/providers/Auth/AuthProvider';
+import { toast } from '@/components/common/ui/Toast';
 
 type SignInValues = {
   email: string;
@@ -31,17 +31,15 @@ export default function SignIn() {
         router.push('/');
       }
     } catch {
-      alert('로그인에 실패했습니다. 이메일 또는 비밀번호를 확인해주세요.');
+      toast.error('이메일 또는 비밀번호를 확인해주세요.', {
+        title: '로그인 실패',
+      });
     }
-  };
-
-  const inValid = (formErrors: FieldErrors<SignInValues>) => {
-    console.log('실패했을때.', formErrors);
   };
 
   return (
     <AuthLayout>
-      <form className="flex flex-col" onSubmit={handleSubmit(valid, inValid)}>
+      <form className="flex flex-col" onSubmit={handleSubmit(valid)}>
         <div className="flex flex-col gap-6 mb-10">
           <FormField
             id="email"

--- a/pages/auth/signup.tsx
+++ b/pages/auth/signup.tsx
@@ -6,6 +6,7 @@ import { useForm } from '@/hooks/useForm/useForm';
 import { useRouter } from 'next/router';
 import { useAuth } from '@/providers/Auth/AuthProvider';
 import { toast } from '@/components/common/ui/Toast';
+import type { FieldErrors } from '@/hooks/useForm';
 
 type SignUpValues = {
   email: string;
@@ -31,9 +32,17 @@ export default function SignUp() {
     }
   };
 
+  const Invalid = (errors: FieldErrors<SignUpValues>) => {
+    const firstError = Object.values(errors)[0];
+    if (!firstError) return;
+    toast.error(firstError, {
+      title: '회원가입 실패',
+    });
+  };
+
   return (
     <AuthLayout>
-      <form className="flex flex-col" onSubmit={handleSubmit(valid)}>
+      <form className="flex flex-col" onSubmit={handleSubmit(valid, Invalid)}>
         <div className="flex flex-col gap-6 mb-10">
           <FormField
             id="email"

--- a/pages/auth/signup.tsx
+++ b/pages/auth/signup.tsx
@@ -3,9 +3,9 @@ import FormField from '@/components/common/form/FormField';
 import Button from '@/components/common/ui/Button';
 import Link from 'next/link';
 import { useForm } from '@/hooks/useForm/useForm';
-import type { FieldErrors } from '@/hooks/useForm/types';
 import { useRouter } from 'next/router';
 import { useAuth } from '@/providers/Auth/AuthProvider';
+import { toast } from '@/components/common/ui/Toast';
 
 type SignUpValues = {
   email: string;
@@ -23,18 +23,17 @@ export default function SignUp() {
     try {
       await signup(data);
       router.push('/');
-    } catch {
-      alert('회원가입에 실패했습니다.');
+    } catch (error) {
+      const apiError = error as { data: { message: string } };
+      toast.error(apiError.data.message, {
+        title: '회원가입 실패',
+      });
     }
-  };
-
-  const inValid = (formErrors: FieldErrors<SignUpValues>) => {
-    console.log('실패했을때.', formErrors);
   };
 
   return (
     <AuthLayout>
-      <form className="flex flex-col" onSubmit={handleSubmit(valid, inValid)}>
+      <form className="flex flex-col" onSubmit={handleSubmit(valid)}>
         <div className="flex flex-col gap-6 mb-10">
           <FormField
             id="email"


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- 로그인 및 회원가입에서 에러가 발생했을때 토스트 메시지가 보이도록 추가하였습니다.
- 회원가입시 누락되어있던 쿠키 생성 로직을 추가하였습니다.

## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.
(예: 이 로직을 훅으로 분리하는 게 맞는지 확신이 안 섭니다. / A방식과 B방식 중 성능 때문에 A를 택했는데 의견 궁금합니다.)

- 로그인 및 회원가입에서 오류가 발생했을때 보여주는 토스트 메시지는 1개만 노출하도록 설계하였습니다.
  - 이 부분에서 form 벨리데이션 검사에 통과하지못한 경우 기존에는 해당 필드에 focus를 주도록 고려하였으나, 화면 이동보다 즉각적인 메시지를 보여주도록 처리하는 방향이 더 좋다고 판단하여 해당 방식으로 반영했습니다.
  해당 부분에 대한 의견 부탁드립니다.

- 성공했을때는 특별히 아무런 메시지 없이 넘어가는 부분이 조금 부자연스러운거같은 느낌입니다.
이 부분도 추가하는게 좋을지 의견 부탁드립니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #183 )

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)

<img width="885" height="1106" alt="image" src="https://github.com/user-attachments/assets/2577e4f1-4e4b-4984-8ff5-be879c49f0dc" />

<img width="888" height="1119" alt="image" src="https://github.com/user-attachments/assets/bd8d9d64-778b-4e18-8282-bd875436f4fc" />

<img width="881" height="1109" alt="image" src="https://github.com/user-attachments/assets/3dcce705-cc3f-40b7-ab16-39badb06f179" />

