### PR TITLE
feat: 토큰 갱신 및 파일업로드 별도 분리

### DIFF
--- a/pages/api/proxy/[...path].ts
+++ b/pages/api/proxy/[...path].ts
@@ -54,15 +54,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       if (newAccessToken) {
         const retryResponse = await forwardRequest(newAccessToken);
-        const retryData = await retryResponse.json();
-        return res.status(retryResponse.status).json(retryData);
+        const retryData = await retryResponse.json().catch(() => null);
+        return res
+          .status(retryResponse.status)
+          .json(retryData ?? { message: '백엔드 재시도 응답 파싱 실패' });
       }
     }
 
-    const data = await response.json();
+    const data = await response.json().catch(() => null);
 
-    return res.status(response.status).json(data);
+    return res.status(response.status).json(data ?? { message: '백엔드 응답 파싱 실패' });
   } catch (error) {
-    return res.status(500).json({ message: '서버 오류가 발생했습니다.', error });
+    console.error('[Proxy Error]', error);
+    return res.status(500).json({ message: '서버 내부 오류가 발생했습니다.' });
   }
 }

--- a/pages/api/proxy/auth/signin.ts
+++ b/pages/api/proxy/auth/signin.ts
@@ -36,7 +36,11 @@ export default async function handler(
       return res.status(response.status).json(errorData);
     }
 
-    const data: AuthResponse = await response.json();
+    const data: AuthResponse = await response.json().catch(() => null);
+
+    if (!data) {
+      return res.status(500).json({ message: '인증 응답 파싱 실패' });
+    }
 
     res.setHeader('Set-Cookie', [
       AUTH_COOKIES.accessToken(data.accessToken),
@@ -52,6 +56,6 @@ export default async function handler(
     });
   } catch (error) {
     console.error('Error signing in:', error);
-    return res.status(500).json({ message: '서버 오류가 발생했습니다.' });
+    return res.status(500).json({ message: '서버 내부 오류가 발생했습니다.' });
   }
 }

--- a/pages/api/proxy/auth/signup.ts
+++ b/pages/api/proxy/auth/signup.ts
@@ -33,7 +33,11 @@ export default async function handler(
       });
     }
 
-    const data: AuthResponse = await response.json();
+    const data: AuthResponse = await response.json().catch(() => null);
+
+    if (!data) {
+      return res.status(500).json({ message: '가입 응답 파싱 실패' });
+    }
 
     return res.status(201).json({
       id: data.user.id,
@@ -43,7 +47,7 @@ export default async function handler(
       updatedAt: data.user.updatedAt,
     });
   } catch (error) {
-    console.error('Error signing in:', error);
-    return res.status(500).json({ message: '서버 오류가 발생했습니다.' });
+    console.error('Error signing up:', error);
+    return res.status(500).json({ message: '서버 내부 오류가 발생했습니다.' });
   }
 }

--- a/pages/api/proxy/images/upload.ts
+++ b/pages/api/proxy/images/upload.ts
@@ -1,0 +1,59 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { refreshAuthSession } from '@/lib/auth/refreshAuthSession';
+
+export const config = {
+  api: { bodyParser: false },
+};
+
+const BASE_URL = process.env.API_URL;
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: '허용된 메소드가 아닙니다.' });
+  }
+
+  try {
+    const { accessToken, refreshToken } = req.cookies;
+
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+    }
+    const rawBody = Buffer.concat(chunks);
+
+    const forwardUpload = (token?: string) => {
+      const headers: Record<string, string> = {};
+
+      if (req.headers['content-type']) {
+        headers['Content-Type'] = req.headers['content-type'];
+      }
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
+      }
+
+      return fetch(`${BASE_URL}/images/upload`, {
+        method: 'POST',
+        headers,
+        body: rawBody,
+      });
+    };
+
+    const response = await forwardUpload(accessToken);
+
+    if (response.status === 401 && refreshToken) {
+      const newAccessToken = await refreshAuthSession({ refreshToken, res });
+
+      if (newAccessToken) {
+        const retryResponse = await forwardUpload(newAccessToken);
+        const retryData = await retryResponse.json();
+        return res.status(retryResponse.status).json(retryData);
+      }
+    }
+
+    const data = await response.json();
+
+    return res.status(response.status).json(data);
+  } catch (error) {
+    return res.status(500).json({ message: '서버 오류가 발생했습니다.', error });
+  }
+}

--- a/pages/api/proxy/images/upload.ts
+++ b/pages/api/proxy/images/upload.ts
@@ -2,7 +2,9 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { refreshAuthSession } from '@/lib/auth/refreshAuthSession';
 
 export const config = {
-  api: { bodyParser: false },
+  api: {
+    bodyParser: false,
+  },
 };
 
 const BASE_URL = process.env.API_URL;
@@ -50,10 +52,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }
     }
 
-    const data = await response.json();
-
-    return res.status(response.status).json(data);
+    const data = await response.json().catch(() => null);
+    return res.status(response.status).json(data ?? { message: '백엔드 응답 파싱 실패' });
   } catch (error) {
-    return res.status(500).json({ message: '서버 오류가 발생했습니다.', error });
+    console.error('[Proxy Error]', error);
+    return res.status(500).json({ message: '서버 내부 오류가 발생했습니다.' });
   }
 }


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- 액세스 토큰이 만료되어 401 에러가 돌아오면 자동 갱신 로직 작성
- 파일업로드 router 별도 분리

## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.
(예: 이 로직을 훅으로 분리하는 게 맞는지 확신이 안 섭니다. / A방식과 B방식 중 성능 때문에 A를 택했는데 의견 궁금합니다.)

- 파일업로드의 경우 캐치 올 세그먼트 부분에서 처리할 수 있었지만 별도로 분리하였습니다.
  - 다소 중복로직이 발생하지만 안정성과 흐름을 명확하게 하기위하여 분리하였습니다. 이 부분에 대한 의견 부탁드립니다.

- 프록시는 최대 2번까지 요청을 보낼 수 있어서 청크 데이터를 받아서 관리하도록 하였습니다.
  - 해당 부분은 AI의 도움을 받았습니다. (처음에는 body 를 그대로 받아서 다시 전달하도록 하려고 했으나 만약에 실패한 경우 문제가 발생할 가능성이 있다고 하여 반영해봤습니다)

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #177 )

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)
