### PR TITLE
feat: myprofile page 프로필 이미지 / 닉네임 수정 기능 구현

### DIFF
--- a/components/common/ui/AvatarPicker.tsx
+++ b/components/common/ui/AvatarPicker.tsx
@@ -1,0 +1,60 @@
+import defaultUserImage from '@/assets/images/default-user-image.png';
+import { cn } from '@/utils/cn';
+import { ImagePicker } from './ImagePicker';
+import { Avatar, AvatarFallback, AvatarImage } from './Avatar/Avatar';
+import Icon from './Icon';
+
+interface AvatarPickerProps {
+  nickname: string;
+  currentImage?: string | null;
+  preview: string | null;
+  error?: string | null;
+  uploading?: boolean;
+  onSelect: (file: File) => void;
+  className?: string;
+}
+
+export default function AvatarPicker({
+  nickname,
+  currentImage,
+  preview,
+  uploading,
+  onSelect,
+  className,
+}: AvatarPickerProps) {
+  const fallback = nickname?.[0] ?? '?';
+  const imageSrc = preview || currentImage || defaultUserImage;
+
+  return (
+    <div className={cn('flex flex-col items-center gap-2', className)}>
+      <ImagePicker
+        preview={null}
+        error={undefined}
+        uploading={uploading}
+        onSelect={onSelect}
+        className="border-0 p-0 w-auto h-auto"
+        placeholder={
+          <div
+            className={cn(
+              'relative rounded-full overflow-hidden group w-20 h-20 md:w-25 md:h-25 lg:w-41 lg:h-41',
+              uploading && 'pointer-events-none opacity-80'
+            )}
+          >
+            <Avatar className="w-full h-full">
+              <AvatarImage src={imageSrc} alt={nickname} sizes="164px" />
+              <AvatarFallback>{fallback}</AvatarFallback>
+            </Avatar>
+            <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity">
+              <Icon name="camera" size={40} />
+            </div>
+            {uploading && (
+              <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/50 text-white text-sm">
+                업로드 중...
+              </div>
+            )}
+          </div>
+        }
+      />
+    </div>
+  );
+}

--- a/components/common/ui/AvatarPicker.tsx
+++ b/components/common/ui/AvatarPicker.tsx
@@ -18,6 +18,7 @@ export default function AvatarPicker({
   nickname,
   currentImage,
   preview,
+  error,
   uploading,
   onSelect,
   className,
@@ -29,7 +30,7 @@ export default function AvatarPicker({
     <div className={cn('flex flex-col items-center gap-2', className)}>
       <ImagePicker
         preview={null}
-        error={undefined}
+        error={error}
         uploading={uploading}
         onSelect={onSelect}
         className="border-0 p-0 w-auto h-auto"

--- a/components/myprofile/MyProfilePage.tsx
+++ b/components/myprofile/MyProfilePage.tsx
@@ -7,6 +7,7 @@ import MyProfileTabs from './MyProfileTabs';
 import { ApiReview } from '@/lib/api/review/review.types';
 import { WineListItem } from '@/lib/api/wine/wine.types';
 import { ApiUser } from '@/lib/api/user/user.types';
+import { useProfileEditor } from '@/hooks/myprofile/userProfileEditor';
 
 type Tab = 'reviews' | 'wines';
 
@@ -26,7 +27,7 @@ interface MyProfilePageProps {
   loadingWines: boolean;
   onFetchReviews: () => void;
   onFetchWines: () => void;
-  onUpdateProfile: (nickname: string, file?: File | null) => void;
+  onUpdateProfile: (nickname: string, imageUrl?: string | null) => void;
   isUpdating: boolean;
   error?: MyProfileErrors;
 }
@@ -44,8 +45,7 @@ export default function MyProfilePage({
   error,
 }: MyProfilePageProps) {
   const [tab, setTab] = useState<Tab>('reviews');
-  const [nickname, setNickname] = useState(user.nickname);
-  const [imageFile, setImageFile] = useState<File | null>(null);
+  const editor = useProfileEditor(user);
 
   useEffect(() => {
     if (tab === 'reviews') onFetchReviews();
@@ -53,8 +53,8 @@ export default function MyProfilePage({
   }, [tab, onFetchReviews, onFetchWines]);
 
   const handleSubmit = () => {
-    onUpdateProfile(nickname, imageFile);
-    setImageFile(null);
+    onUpdateProfile(editor.derived.nextNickname, editor.derived.nextImage);
+    editor.resetUploadedImage();
   };
 
   return (
@@ -62,10 +62,14 @@ export default function MyProfilePage({
       sidebar={
         <ProfileSidebar
           user={user}
-          nickname={nickname}
-          onNicknameChange={setNickname}
-          onImageChange={setImageFile}
+          nickname={editor.nickname}
+          onNicknameChange={editor.setNickname}
+          avatarPreview={editor.picker.preview}
+          avatarError={editor.picker.error}
+          avatarUploading={editor.picker.uploading}
+          onSelectAvatar={editor.picker.handleFile}
           onSubmit={handleSubmit}
+          submitDisabled={editor.derived.isDisabled}
           isUpdating={isUpdating}
           error={error?.profile ?? undefined}
         />

--- a/components/myprofile/ProfileSidebar.tsx
+++ b/components/myprofile/ProfileSidebar.tsx
@@ -1,10 +1,8 @@
 import { User } from '@/types/auth/auth';
-import { Avatar, AvatarFallback, AvatarImage } from '../common/ui/Avatar';
 import Button from '../common/ui/Button';
 import FormField from '../common/form/FormField';
-import Icon from '../common/ui/Icon';
-import defaultUserImage from '@/assets/images/default-user-image.png';
-import { useEffect, useState } from 'react';
+import AvatarPicker from '../common/ui/AvatarPicker';
+import Spinner from '../common/ui/Spinner';
 
 type UserProfile = Pick<User, 'image' | 'nickname'>;
 
@@ -12,94 +10,39 @@ interface ProfileSidebarProps {
   user: UserProfile;
   nickname: string;
   onNicknameChange: (value: string) => void;
+  avatarPreview: string | null;
+  avatarError?: string | null;
+  avatarUploading?: boolean;
+  onSelectAvatar: (file: File) => void;
   onSubmit: () => void;
-  onImageChange?: (file: File | null) => void;
+  submitDisabled?: boolean;
   isUpdating?: boolean;
   error?: string;
-}
-
-const MAX_FILE_SIZE = 5 * 1024 * 1024;
-
-function getProfileDerivedState(user: UserProfile, nickname: string, preview: string | null) {
-  const imageSrc = preview || user.image || defaultUserImage;
-  const isNicknameChanged = nickname.trim() !== user.nickname;
-  const isImageChanged = !!preview;
-  const isDirty = isNicknameChanged || isImageChanged;
-
-  return {
-    imageSrc,
-    isDisabled: !isDirty || !nickname.trim(),
-  };
 }
 
 export default function ProfileSidebar({
   user,
   nickname,
   onNicknameChange,
+  avatarPreview,
+  avatarError,
+  avatarUploading,
+  onSelectAvatar,
   onSubmit,
-  onImageChange,
+  submitDisabled,
   isUpdating,
   error,
 }: ProfileSidebarProps) {
-  const [preview, setPreview] = useState<string | null>(null);
-  const [fileError, setFileError] = useState<string | null>(null);
-  const fallback = user.nickname?.[0] ?? '?';
-  const fileInputId = 'profile-image-input';
-
-  const { imageSrc, isDisabled } = getProfileDerivedState(user, nickname, preview);
-
-  const handleUploadFile = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    setFileError(null);
-
-    if (!file.type.startsWith('image/')) {
-      setFileError('이미지 파일만 업로드할 수 있습니다.');
-      return;
-    }
-
-    if (file.size > MAX_FILE_SIZE) {
-      setFileError('파일 크기는 5MB 이하만 가능합니다.');
-      return;
-    }
-    onImageChange?.(file);
-    setPreview(prev => {
-      if (prev) URL.revokeObjectURL(prev);
-      return URL.createObjectURL(file);
-    });
-    e.target.value = '';
-  };
-
-  useEffect(() => {
-    return () => {
-      if (preview) URL.revokeObjectURL(preview);
-    };
-  }, [preview]);
-
   return (
     <div className="w-full flex flex-col mt-12 sticky top-10 items-center gap-5">
-      <label
-        className="relative group cursor-pointer"
-        htmlFor={fileInputId}
-        aria-label="프로필 이미지 변경"
-      >
-        <Avatar className="lg:w-41 lg:h-41 md:w-25 md:h-25 w-20 h-20">
-          <AvatarImage src={imageSrc} alt={user.nickname} sizes="164px" />
-          <AvatarFallback>{fallback}</AvatarFallback>
-        </Avatar>
-        <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity">
-          <Icon name="camera" size={40} />
-        </div>
-      </label>
-      <input
-        id={fileInputId}
-        type="file"
-        accept="image/*"
-        className="sr-only"
-        onChange={handleUploadFile}
+      <AvatarPicker
+        nickname={user.nickname}
+        currentImage={user.image}
+        preview={avatarPreview}
+        error={avatarError}
+        uploading={avatarUploading}
+        onSelect={onSelectAvatar}
       />
-      {fileError && <p className="text-sm text-red-500">{fileError}</p>}
       <p className="text-2xl font-semibold mb-1">{user.nickname}</p>
       <div className="flex gap-4 lg:flex-col lg:items-center lg:justify-center">
         <div className="w-47.5 md:w-71.5 lg:w-60 lg:mb-3">
@@ -116,10 +59,11 @@ export default function ProfileSidebar({
         <Button
           className="self-end lg:self-center max-w-24.5"
           size="sm"
-          disabled={isDisabled || isUpdating}
+          disabled={submitDisabled || isUpdating}
           onClick={onSubmit}
         >
-          {isUpdating ? '처리 중...' : '변경하기'}
+          {isUpdating && <Spinner size="xs" />}
+          {isUpdating ? '' : '변경하기'}
         </Button>
       </div>
     </div>

--- a/hooks/imagePicker/useImagePicker.ts
+++ b/hooks/imagePicker/useImagePicker.ts
@@ -45,7 +45,6 @@ export function useImagePicker({ rules, onUploaded }: useImagePickerOptions) {
       } catch (err) {
         console.error('이미지 업로드 실패', err);
         setError('이미지 업로드 실패했습니다.');
-        toast.error('이미지 업로드 실패했습니다.');
       } finally {
         setUploading(false);
       }

--- a/hooks/imagePicker/useImagePicker.ts
+++ b/hooks/imagePicker/useImagePicker.ts
@@ -1,3 +1,4 @@
+import { toast } from '@/components/common/ui/Toast';
 import { uploadImage } from '@/lib/api/infra/image';
 import { ImageValidation, ValidationRule } from '@/utils/imagePicker/ImageValidation';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -44,6 +45,7 @@ export function useImagePicker({ rules, onUploaded }: useImagePickerOptions) {
       } catch (err) {
         console.error('이미지 업로드 실패', err);
         setError('이미지 업로드 실패했습니다.');
+        toast.error('이미지 업로드 실패했습니다.');
       } finally {
         setUploading(false);
       }

--- a/hooks/myprofile/useUpdateProfile.ts
+++ b/hooks/myprofile/useUpdateProfile.ts
@@ -1,4 +1,4 @@
-import { uploadImage } from '@/lib/api/infra/image';
+import { toast } from '@/components/common/ui/Toast';
 import { updateMe } from '@/lib/api/user/user';
 import { useAuth } from '@/providers/Auth/AuthProvider';
 import { useState } from 'react';
@@ -8,28 +8,36 @@ export function useUpdateProfile() {
   const [isUpdating, setIsUpdating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const updateProfile = async (nickname: string, file?: File | null) => {
+  const updateProfile = async (nickname: string, imageUrl?: string | null) => {
     if (!user) return;
-    if (!file && nickname === user.nickname) return;
+
+    const nextNickname = nickname.trim();
+    const nextImage = imageUrl ?? user.image;
+
+    if (nextNickname === user.nickname && nextImage === user.image) return;
 
     try {
+      setError(null);
       setIsUpdating(true);
 
-      let imageUrl = user.image;
+      const body: { nickname: string; image?: string } = {
+        nickname: nextNickname,
+      };
 
-      if (file) {
-        const res = await uploadImage(file);
-        imageUrl = res.url;
+      if (typeof nextImage === 'string' && nextImage.length > 0) {
+        body.image = nextImage;
       }
 
-      const updatedUser = await updateMe({
-        nickname,
-        image: imageUrl,
-      });
+      const updatedUser = await updateMe(body);
 
       updateUser(updatedUser);
-    } catch {
-      setError('프로필 수정에 실패했습니다.');
+      toast.success('프로필이 수정되었습니다.');
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        toast.error(err.message);
+      } else {
+        toast.error('프로필 수정에 실패했습니다.');
+      }
     } finally {
       setIsUpdating(false);
     }

--- a/hooks/myprofile/userProfileEditor.ts
+++ b/hooks/myprofile/userProfileEditor.ts
@@ -1,0 +1,48 @@
+import { ApiUser } from '@/lib/api/user/user.types';
+import { useEffect, useMemo, useState } from 'react';
+import { useImagePicker } from '../imagePicker/useImagePicker';
+import { isImage, maxSize } from '@/utils/imagePicker/ImageValidation';
+
+type UserProfile = Pick<ApiUser, 'image' | 'nickname'>;
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+export function useProfileEditor(user: UserProfile) {
+  const [nickname, setNickname] = useState(() => user.nickname);
+  const [uploadedImageUrl, setUploadedImageUrl] = useState<string | null>(null);
+
+  const picker = useImagePicker({
+    rules: [isImage, maxSize(MAX_FILE_SIZE)],
+    onUploaded: url => setUploadedImageUrl(url),
+  });
+
+  const derived = useMemo(() => {
+    const nextNickname = nickname.trim();
+    const nextImage = uploadedImageUrl ?? user.image;
+
+    const isNicknameChange = nextNickname !== user.nickname;
+    const isImageChanged = nextImage !== user.image;
+
+    const isDirty = isNicknameChange || isImageChanged;
+    const isDisabled = !isDirty || !nextNickname || picker.uploading || !!picker.error;
+
+    return {
+      nextNickname,
+      nextImage,
+      isDirty,
+      isDisabled,
+    };
+  }, [nickname, uploadedImageUrl, user.nickname, user.image, picker.uploading, picker.error]);
+
+  const resetUploadedImage = () => setUploadedImageUrl(null);
+
+  return {
+    nickname,
+    setNickname,
+    uploadedImageUrl,
+    setUploadedImageUrl,
+    resetUploadedImage,
+    picker,
+    derived,
+  };
+}


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- myprofile page 프로필 이미지 / 닉네임 수정 기능 구현했습니다.

## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.
(예: 이 로직을 훅으로 분리하는 게 맞는지 확신이 안 섭니다. / A방식과 B방식 중 성능 때문에 A를 택했는데 의견 궁금합니다.)

- 닉네임, user avatar update check 완료 했습니다.
- avatarpicker wrapper 컴포넌트를 추가했습니다. (기존 원형 avatar UI 및 hover camera 유지)
- 프로필 편집 상태 전용 hook을 추가했습니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
Closes #191 

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)

- 기존
<img width="316" height="476" alt="image" src="https://github.com/user-attachments/assets/9956624f-07f5-488e-acb4-6663ed4437d5" />

-  변경
<img width="331" height="468" alt="image" src="https://github.com/user-attachments/assets/23db931e-37df-48d1-863e-56c6df78292b" />


