### PR TITLE
feat: myprofile page 와인 수정 + 와인 삭제 기능 구현

### DIFF
--- a/components/myprofile/MyProfileContainer.tsx
+++ b/components/myprofile/MyProfileContainer.tsx
@@ -1,8 +1,10 @@
 import { useAuth } from '@/providers/Auth/AuthProvider';
 import MyProfilePage from './MyProfilePage';
-import { useMyReviews } from '@/hooks/myprofile/useMyReviews';
-import { useMyWines } from '@/hooks/myprofile/useMyWines';
-import { useUpdateProfile } from '@/hooks/myprofile/useUpdateProfile';
+import { useMyReviews, useMyWines, useUpdateProfile } from '@/hooks/myprofile';
+import { deleteWine } from '@/lib/api/wine/wine';
+import { toast } from '../common/ui/Toast';
+import type { Wine } from '@/types/domain/wine';
+import type { WineListItem } from '@/lib/api/wine/wine.types';
 
 interface MyProfileErrors {
   profile?: string | null;
@@ -29,6 +31,28 @@ export default function MyProfileContainer() {
     nickname: user.nickname,
     image: user.image,
   };
+
+  const handleDeleteWine = async (id: number) => {
+    try {
+      await deleteWine(id);
+      winesState.removeLocalWine(id);
+      toast.success('와인이 삭제되었습니다.');
+    } catch {
+      toast.error('와인 삭제에 실패했습니다.');
+    }
+  };
+
+  const handleUpdateWineLocal = (id: number, wine: Wine) => {
+    const patch: Partial<WineListItem> = {
+      name: wine.name,
+      price: wine.price,
+      region: wine.region,
+      image: wine.image,
+      type: wine.type,
+    };
+    winesState.updateLocalWine(id, patch);
+  };
+
   return (
     <MyProfilePage
       key={`${user.nickname}-${user.image}`}
@@ -39,6 +63,8 @@ export default function MyProfileContainer() {
       loadingWines={winesState.loading}
       onFetchReviews={reviewsState.fetch}
       onFetchWines={winesState.fetch}
+      onDeleteWine={handleDeleteWine}
+      onUpdateWineLocal={handleUpdateWineLocal}
       onUpdateProfile={profileState.updateProfile}
       isUpdating={profileState.isUpdating}
       error={errors}

--- a/components/myprofile/MyProfilePage.tsx
+++ b/components/myprofile/MyProfilePage.tsx
@@ -4,13 +4,13 @@ import MyReviewsPanel from './MyReviewsPanel';
 import MyWinesPanel from './MyWinesPanel';
 import MyProfileLayout from './MyProfileLayout';
 import MyProfileTabs from './MyProfileTabs';
-import { ApiReview } from '@/lib/api/review/review.types';
-import { WineListItem } from '@/lib/api/wine/wine.types';
-import { ApiUser } from '@/lib/api/user/user.types';
 import { useProfileEditor } from '@/hooks/myprofile/userProfileEditor';
+import type { ApiReview } from '@/lib/api/review/review.types';
+import type { WineListItem } from '@/lib/api/wine/wine.types';
+import type { ApiUser } from '@/lib/api/user/user.types';
+import type { Wine } from '@/types/domain/wine';
 
 type Tab = 'reviews' | 'wines';
-
 type UserProfile = Pick<ApiUser, 'image' | 'nickname'>;
 
 interface MyProfileErrors {
@@ -30,6 +30,8 @@ interface MyProfilePageProps {
   onUpdateProfile: (nickname: string, imageUrl?: string | null) => void;
   isUpdating: boolean;
   error?: MyProfileErrors;
+  onDeleteWine: (id: number) => void;
+  onUpdateWineLocal: (id: number, wine: Wine) => void;
 }
 
 export default function MyProfilePage({
@@ -43,6 +45,8 @@ export default function MyProfilePage({
   onUpdateProfile,
   isUpdating,
   error,
+  onDeleteWine,
+  onUpdateWineLocal,
 }: MyProfilePageProps) {
   const [tab, setTab] = useState<Tab>('reviews');
   const editor = useProfileEditor(user);
@@ -78,7 +82,14 @@ export default function MyProfilePage({
         <>
           <MyProfileTabs value={tab} onChange={setTab} />
           {tab === 'reviews' && <MyReviewsPanel reviews={reviews} loading={loadingReviews} />}
-          {tab === 'wines' && <MyWinesPanel wines={wines} loading={loadingWines} />}
+          {tab === 'wines' && (
+            <MyWinesPanel
+              wines={wines}
+              loading={loadingWines}
+              onDeleteWine={onDeleteWine}
+              onUpdateWineLocal={onUpdateWineLocal}
+            />
+          )}
         </>
       }
     />

--- a/components/myprofile/MyWinesPanel.tsx
+++ b/components/myprofile/MyWinesPanel.tsx
@@ -1,15 +1,38 @@
 import { cn } from '@/utils/cn';
 import MyWineCard from '../mywinecard/MyWineCard';
-import { WineListItem } from '@/lib/api/wine/wine.types';
 import EmptyState from '../common/ui/EmptyState';
+import WineFormModal from '../wine/WineFormModal';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../common/ui/AlertDialog';
+import { useMyWinesPanelState } from '@/hooks/myprofile';
+import type { Wine } from '@/types/domain/wine';
+import type { WineListItem } from '@/lib/api/wine/wine.types';
 
 interface MyWinesPanelProps {
   wines: WineListItem[];
   loading: boolean;
+  onDeleteWine: (id: number) => void;
+  onUpdateWineLocal: (id: number, wine: Wine) => void;
   className?: string;
 }
 
-export default function MyWinesPanel({ wines, loading, className }: MyWinesPanelProps) {
+export default function MyWinesPanel({
+  wines,
+  loading,
+  onDeleteWine,
+  onUpdateWineLocal,
+  className,
+}: MyWinesPanelProps) {
+  const state = useMyWinesPanelState({ onDeleteWine, onUpdateWineLocal });
+
   if (loading) return null;
 
   if (!wines.length) {
@@ -28,18 +51,46 @@ export default function MyWinesPanel({ wines, loading, className }: MyWinesPanel
     );
   }
   return (
-    <section
-      role="tabpanel"
-      id="panel-wines"
-      aria-labelledby="tab-wines"
-      className={cn(
-        'relative lg:pl-8 pt-10 lg:border-l border-t border-gray-300 grid grid-cols-1 md:grid-cols-2 gap-x-4 lg:gap-x-18 md:gap-y-0',
-        className
-      )}
-    >
-      {wines.map(wine => (
-        <MyWineCard key={wine.id} wine={wine} />
-      ))}
-    </section>
+    <>
+      <section
+        role="tabpanel"
+        id="panel-wines"
+        aria-labelledby="tab-wines"
+        className={cn(
+          'relative lg:pl-8 pt-10 lg:border-l border-t border-gray-300 grid grid-cols-1 md:grid-cols-2 gap-x-4 lg:gap-x-18 md:gap-y-0',
+          className
+        )}
+      >
+        {wines.map(wine => (
+          <MyWineCard
+            key={wine.id}
+            wine={wine}
+            onEdit={state.openEdit}
+            onDelete={state.openDelete}
+          />
+        ))}
+      </section>
+      <WineFormModal
+        open={state.editOpen}
+        onOpenChange={state.setEditOpen}
+        mode="edit"
+        wine={state.editingWine ?? undefined}
+        onSuccess={state.handleEditSuccess}
+      />
+
+      <AlertDialog open={state.deleteOpen} onOpenChange={state.setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>와인을 삭제하시겠습니까?</AlertDialogTitle>
+            <AlertDialogDescription>삭제한 와인은 복구할 수 없습니다.</AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction onClick={state.handleConfirmDelete}>삭제</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/components/mywinecard/MyWineCard.tsx
+++ b/components/mywinecard/MyWineCard.tsx
@@ -1,13 +1,12 @@
-import { Wine } from '@/types/domain/wine';
 import Image from 'next/image';
-import MyWineCardMenu from './MyWineCardMenu';
 import MyWineCardInfo from './MyWineCardInfo';
 import { cn } from '@/utils/cn';
+import { WineListItem } from '@/lib/api/wine/wine.types';
 
 interface MyWineCardProps {
-  wine: Wine;
-  onEdit?: (wine: Wine) => void;
-  onDelete?: (wine: Wine) => void;
+  wine: WineListItem;
+  onEdit?: (wine: WineListItem) => void;
+  onDelete?: (wine: WineListItem) => void;
   className?: string;
 }
 

--- a/components/mywinecard/MyWineCardInfo.tsx
+++ b/components/mywinecard/MyWineCardInfo.tsx
@@ -1,7 +1,7 @@
-import { Wine } from '@/types/domain/wine';
 import MyWineCardMenu from './MyWineCardMenu';
+import { WineListItem } from '@/lib/api/wine/wine.types';
 
-type MyWineCardInfoProps = Pick<Wine, 'name' | 'region' | 'price'> & {
+type MyWineCardInfoProps = Pick<WineListItem, 'name' | 'region' | 'price'> & {
   onEdit?: () => void;
   onDelete?: () => void;
 };

--- a/components/wine/WineForm.tsx
+++ b/components/wine/WineForm.tsx
@@ -3,16 +3,16 @@ import Button from '../common/ui/Button';
 import Chip from '../common/ui/chip';
 import Input from '../common/ui/Input';
 import WineImageUpload from './WineImageUpload';
-import { Wine, WineType } from '@/types/domain/wine';
 import { useState } from 'react';
 import { useForm } from '@/hooks/useForm';
-import Spinner from '../common/ui/Spinner';
 import { WINE_PRICE_MAX } from '@/constants/wine';
+import type { Wine, WineType } from '@/types/domain/wine';
 
 type Mode = 'create' | 'edit';
 
 interface WineFormProps {
   mode: Mode;
+  initialWine?: Wine;
   onSuccess?: (wine: Wine) => void;
 }
 
@@ -27,10 +27,10 @@ interface WineFormFields {
 
 const WINE_TYPES = ['RED', 'WHITE', 'SPARKLING'] as const;
 
-export default function WineForm({ mode, onSuccess }: WineFormProps) {
-  const form = useWineForm({ mode, onSuccess });
-  const [type, setType] = useState<WineType | ''>('');
-  const [image, setImage] = useState('');
+export default function WineForm({ mode, initialWine, onSuccess }: WineFormProps) {
+  const form = useWineForm({ mode, wineId: initialWine?.id, onSuccess });
+  const [type, setType] = useState<WineType | ''>(initialWine?.type ?? '');
+  const [image, setImage] = useState(initialWine?.image ?? '');
   const { register, handleSubmit, errors } = useForm<WineFormFields>({ mode: 'onSubmit' });
 
   const onSubmit = handleSubmit(async values => {
@@ -38,8 +38,8 @@ export default function WineForm({ mode, onSuccess }: WineFormProps) {
       ...values,
       price: Number(values.price),
       type: values.type as WineType,
+      image,
     });
-    console.log('values:', values);
   });
 
   return (
@@ -47,6 +47,7 @@ export default function WineForm({ mode, onSuccess }: WineFormProps) {
       <WineImageUpload value={image} onChange={setImage} error={errors.image} />
       <input
         type="hidden"
+        defaultValue={initialWine?.image}
         {...register('image', {
           required: '와인 사진은 필수 입력이에요',
         })}
@@ -56,6 +57,7 @@ export default function WineForm({ mode, onSuccess }: WineFormProps) {
       <div className="flex flex-col gap-2">
         <span>와인 이름</span>
         <Input
+          defaultValue={initialWine?.name}
           {...register('name', {
             required: '와인 이름은 필수 입력이에요',
           })}
@@ -68,6 +70,7 @@ export default function WineForm({ mode, onSuccess }: WineFormProps) {
       <div className="flex flex-col gap-2">
         <span>가격</span>
         <Input
+          defaultValue={initialWine ? String(initialWine.price) : ''}
           {...register('price', {
             required: '가격은 필수 입력이에요',
             validate: value => {
@@ -96,10 +99,11 @@ export default function WineForm({ mode, onSuccess }: WineFormProps) {
         </div>
         <input
           type="hidden"
+          defaultValue={initialWine?.type}
           {...register('type', {
             required: '와인 타입은 필수 입력이에요',
           })}
-          value={type ?? ''}
+          value={type}
         />
         {errors.type && <p className="text-red-500 text-[12px]">{errors.type}</p>}
       </div>
@@ -107,6 +111,7 @@ export default function WineForm({ mode, onSuccess }: WineFormProps) {
       <div className="flex flex-col gap-2">
         <span>원산지</span>
         <Input
+          defaultValue={initialWine?.region}
           {...register('region', {
             required: '원산지는 필수 입력이에요',
           })}
@@ -119,7 +124,7 @@ export default function WineForm({ mode, onSuccess }: WineFormProps) {
       {form.formError && <p className="text-red-500 text-[12px] font-medium">{form.formError}</p>}
 
       <Button type="submit" disabled={form.isSubmitting}>
-        {form.isSubmitting ? <Spinner /> : form.isEdit ? '와인 수정하기' : '와인 등록하기'}
+        {form.isEdit ? '와인 수정하기' : '와인 등록하기'}
       </Button>
     </form>
   );

--- a/components/wine/WineFormModal.tsx
+++ b/components/wine/WineFormModal.tsx
@@ -7,18 +7,20 @@ import {
   DialogClose,
 } from '@/components/common/ui/Dialog';
 import WineForm from './WineForm';
-import { Dispatch, SetStateAction } from 'react';
 import IconButton from '../common/ui/IconButton';
-import { Wine } from '@/types/domain/wine';
+import type { Dispatch, SetStateAction } from 'react';
+import type { Wine } from '@/types/domain/wine';
+import type { WineListItem } from '@/lib/api/wine/wine.types';
 
 interface Props {
   open: boolean;
   onOpenChange: Dispatch<SetStateAction<boolean>>;
   mode: 'create' | 'edit';
+  wine?: WineListItem;
   onSuccess?: (wine: Wine) => void;
 }
 
-export default function WineFormModal({ open, onOpenChange, mode, onSuccess }: Props) {
+export default function WineFormModal({ open, onOpenChange, mode, wine, onSuccess }: Props) {
   const isEdit = mode === 'edit';
 
   const handleSuccess = (wine: Wine) => {
@@ -38,7 +40,12 @@ export default function WineFormModal({ open, onOpenChange, mode, onSuccess }: P
           </DialogClose>
         </DialogHeader>
         <DialogBody>
-          <WineForm mode={mode} onSuccess={handleSuccess} />
+          <WineForm
+            key={wine?.id ?? 'create'}
+            mode={mode}
+            initialWine={wine}
+            onSuccess={handleSuccess}
+          />
         </DialogBody>
       </DialogContent>
     </Dialog>

--- a/hooks/list/useWineForm.ts
+++ b/hooks/list/useWineForm.ts
@@ -1,12 +1,13 @@
 import { useState } from 'react';
-import { createWine } from '@/lib/api/wine/wine';
-import type { CreateWineRequest } from '@/lib/api/wine/wine.types';
+import { createWine, updateWine } from '@/lib/api/wine/wine';
+import type { CreateWineRequest, UpdateWineRequest } from '@/lib/api/wine/wine.types';
 import type { Wine, WineType } from '@/types/domain/wine';
 import { toast } from '@/components/common/ui/Toast';
 import { WINE_PRICE_MAX, WINE_PRICE_MIN } from '@/constants/wine';
 
 interface useWineFormParams {
   mode: 'create' | 'edit';
+  wineId?: number;
   onSuccess?: (wine: Wine) => void;
 }
 
@@ -18,12 +19,12 @@ interface WineFormValues {
   image: string;
 }
 
-function extractErrorMessage(err: unknown): string {
+function extractErrorMessage(err: unknown, isEdit: boolean): string {
   if (err instanceof Error) return err.message;
-  return '와인 등록에 실패했습니다.';
+  return isEdit ? '와인 수정에 실패했습니다.' : '와인 등록에 실패했습니다.';
 }
 
-export function useWineForm({ mode, onSuccess }: useWineFormParams) {
+export function useWineForm({ mode, wineId, onSuccess }: useWineFormParams) {
   const isEdit = mode === 'edit';
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
@@ -48,13 +49,20 @@ export function useWineForm({ mode, onSuccess }: useWineFormParams) {
         image: values.image,
       };
 
-      const createdWine = await createWine(payload);
-      toast.success('와인이 등록되었습니다.');
-      onSuccess?.(createdWine);
+      let result: Wine;
+
+      if (isEdit && wineId) {
+        result = await updateWine(wineId, payload as UpdateWineRequest);
+        toast.success('와인이 수정되었습니다.');
+      } else {
+        result = await createWine(payload as CreateWineRequest);
+        toast.success('와인이 등록되었습니다.');
+      }
+      onSuccess?.(result);
     } catch (err) {
-      const message = extractErrorMessage(err);
+      const message = extractErrorMessage(err, isEdit);
       toast.error(message);
-      setFormError(null);
+      setFormError(message);
     } finally {
       setIsSubmitting(false);
     }

--- a/hooks/myprofile/index.ts
+++ b/hooks/myprofile/index.ts
@@ -1,0 +1,6 @@
+export * from './useMyReviews';
+export * from './useMyWineActions';
+export * from './useMyWines';
+export * from './useUpdateProfile';
+export * from './userProfileEditor';
+export * from './useMyWinesPanelState';

--- a/hooks/myprofile/useMyWineActions.ts
+++ b/hooks/myprofile/useMyWineActions.ts
@@ -1,0 +1,33 @@
+import { deleteWine, updateWine } from '@/lib/api/wine/wine';
+import { useMyWines } from './useMyWines';
+import { toast } from '@/components/common/ui/Toast';
+import { UpdateWineRequest } from '@/lib/api/wine/wine.types';
+
+type WinesState = ReturnType<typeof useMyWines>;
+
+export function useMyWineActions(winesState: WinesState) {
+  const handleDeleteWine = async (id: number) => {
+    try {
+      await deleteWine(id);
+      winesState.removeLocalWine(id);
+      toast.success('와인이 삭제되었습니다.');
+    } catch {
+      toast.error('와인 삭제에 실패했습니다.');
+    }
+  };
+
+  const handleUpdateWine = async (id: number, body: UpdateWineRequest) => {
+    try {
+      const updated = await updateWine(id, body);
+      winesState.updateLocalWine(id, updated);
+      toast.success('와인이 수정되었습니다.');
+    } catch {
+      toast.error('와인 수정에 실패했습니다.');
+    }
+  };
+
+  return {
+    handleDeleteWine,
+    handleUpdateWine,
+  };
+}

--- a/hooks/myprofile/useMyWines.ts
+++ b/hooks/myprofile/useMyWines.ts
@@ -1,6 +1,6 @@
 import { getMyWines } from '@/lib/api/user/user';
-import { WineListItem } from '@/lib/api/wine/wine.types';
 import { useCallback, useState } from 'react';
+import type { WineListItem } from '@/lib/api/wine/wine.types';
 
 export function useMyWines(limit = 10) {
   const [wines, setWines] = useState<WineListItem[]>([]);
@@ -9,8 +9,7 @@ export function useMyWines(limit = 10) {
   const [hasFetched, setHasFetched] = useState(false);
 
   const fetch = useCallback(async () => {
-    if (loading) return;
-    if (hasFetched) return;
+    if (loading || hasFetched) return;
 
     try {
       setError(null);
@@ -25,5 +24,13 @@ export function useMyWines(limit = 10) {
     }
   }, [loading, hasFetched, limit]);
 
-  return { wines, loading, error, fetch };
+  const removeLocalWine = useCallback((id: number) => {
+    setWines(prev => prev.filter(w => w.id !== id));
+  }, []);
+
+  const updateLocalWine = useCallback((id: number, patch: Partial<WineListItem>) => {
+    setWines(prev => prev.map(w => (w.id === id ? { ...w, ...patch } : w)));
+  }, []);
+
+  return { wines, loading, error, fetch, removeLocalWine, updateLocalWine };
 }

--- a/hooks/myprofile/useMyWinesPanelState.ts
+++ b/hooks/myprofile/useMyWinesPanelState.ts
@@ -1,0 +1,54 @@
+import type { WineListItem } from '@/lib/api/wine/wine.types';
+import type { Wine } from '@/types/domain/wine';
+import { useState } from 'react';
+
+interface useMyWinesPanelStateParams {
+  onDeleteWine: (id: number) => void;
+  onUpdateWineLocal: (id: number, wine: Wine) => void;
+}
+
+export function useMyWinesPanelState({
+  onDeleteWine,
+  onUpdateWineLocal,
+}: useMyWinesPanelStateParams) {
+  const [editingWine, setEditingWine] = useState<WineListItem | null>(null);
+  const [editOpen, setEditOpen] = useState(false);
+  const [deletingWine, setDeletingWine] = useState<WineListItem | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const openEdit = (wine: WineListItem) => {
+    setEditingWine(wine);
+    setEditOpen(true);
+  };
+
+  const handleEditSuccess = (updated: Wine) => {
+    if (!updated?.id) return;
+    onUpdateWineLocal(updated.id, updated);
+    setEditingWine(null);
+  };
+
+  const openDelete = (wine: WineListItem) => {
+    setDeletingWine(wine);
+    setDeleteOpen(true);
+  };
+
+  const handleConfirmDelete = () => {
+    if (!deletingWine) return;
+    onDeleteWine(deletingWine.id);
+    setDeletingWine(null);
+    setDeleteOpen(false);
+  };
+
+  return {
+    editingWine,
+    editOpen,
+    setEditOpen,
+    openEdit,
+    handleEditSuccess,
+    deletingWine,
+    deleteOpen,
+    setDeleteOpen,
+    openDelete,
+    handleConfirmDelete,
+  };
+}


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- myprofile page 와인 수정 기능 구현
- myprofile page 와인 삭제 기능 구현

## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.
(예: 이 로직을 훅으로 분리하는 게 맞는지 확신이 안 섭니다. / A방식과 B방식 중 성능 때문에 A를 택했는데 의견 궁금합니다.)

- myprofile page의 내가 등록한 와인 수정 / 삭제 기능을 구현했습니다.
- 최대한 분리하고, 정상 작동 테스트 완료 했습니다.
- alert dialog 버튼 색 두개가 같아서 헷갈리는데 삭제쪽을 빨간색으로 바꿀까 고민입니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
Closes #202 

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)

https://github.com/user-attachments/assets/0b930610-a08d-4bb3-85f6-d56715fadc24

