### PR TITLE
fix: 빌드 실패시 즉시 알람

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
           context: .
           push: true
           tags: ghcr.io/codeit-21-part-3-team-3/wine:latest
-          build-args: |
+          secrets: |
             API_URL=${{ secrets.API_URL }}
 
       # 성공 시 n8n을 통해 서버 배포 명령 전달
@@ -42,13 +42,13 @@ jobs:
         run: |
           curl -X POST ${{ secrets.N8N_WEBHOOK_URL }} \
           -H "Content-Type: application/json" \
+          -H "X-Webhook-Secret: ${{ secrets.N8N_WEBHOOK_SECRET_TOKEN }}" \
           -d '{
             "status": "success",
             "project": "Wine",
             "branch": "${{ github.ref_name }}",
             "author": "${{ github.actor }}",
             "image": "ghcr.io/codeit-21-part-3-team-3/wine:latest",
-            "API_URL": "${{ secrets.API_URL }}"
           }'
 
       # 실패 시 n8n을 통해 디스코드 알림 전달
@@ -57,9 +57,11 @@ jobs:
         run: |
           curl -X POST ${{ secrets.N8N_WEBHOOK_URL }} \
           -H "Content-Type: application/json" \
+          -H "X-Webhook-Secret: ${{ secrets.N8N_WEBHOOK_SECRET_TOKEN }}" \
           -d '{
             "status": "failure",
             "project": "Wine",
             "branch": "${{ github.ref_name }}",
+            "author": "${{ github.actor }}",
             "error_log": "GitHub Actions Docker Build Failed"
           }'

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,14 @@ RUN npm ci
 FROM node:22-alpine AS builder
 WORKDIR /app
 
-ARG API_URL
-ENV API_URL=$API_URL \
-    NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_TELEMETRY_DISABLED=1
 
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-RUN npm run build
+RUN --mount=type=secret,id=API_URL \
+    API_URL=$(cat /run/secrets/API_URL) \
+    npm run build
 
 FROM node:22-alpine AS runner
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     restart: unless-stopped
     ports:
       - '2133:3000'
+    env_file:
+      - .env
     environment:
-      - API_URL=${API_URL}
       - NODE_ENV=production
     volumes:
       - ./next-cache:/app/.next/cache
-    restart: always


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- 빌드실패시 다른작업하지않고 바로 디스코드로 알람 가도록 조정

## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.
(예: 이 로직을 훅으로 분리하는 게 맞는지 확신이 안 섭니다. / A방식과 B방식 중 성능 때문에 A를 택했는데 의견 궁금합니다.)

- 정체를 알 수 없는 사람이 제 웹훅에 접근하였습니다..  그리하여 보안을 더 강화하였으며 빌드실패시 바로 디스코드로 오도록 하였습니다.
- 누락되어있던 어떤 PR에서 실패했는지 추가했습니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
(예: Closes #212 )

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)

<img width="1013" height="1078" alt="image" src="https://github.com/user-attachments/assets/04c303fa-dfdb-4dcd-966b-4851d74978b7" />
