### PR TITLE
refactor: myprofile 페이지 디자인 고도화 + 이미지 즉시 반영 로직

### DIFF
--- a/components/common/layout/Container.tsx
+++ b/components/common/layout/Container.tsx
@@ -8,9 +8,7 @@ interface ContainerProps {
 
 export default function Container({ children, className }: ContainerProps) {
   return (
-    <div
-      className={cn('w-full mx-auto max-w-[1140px] box-border', 'px-4 sm:px-6 lg:px-0', className)}
-    >
+    <div className={cn('w-full mx-auto max-w-300 box-border', 'px-4 sm:px-6 lg:px-0', className)}>
       {children}
     </div>
   );

--- a/components/common/ui/AvatarPicker.tsx
+++ b/components/common/ui/AvatarPicker.tsx
@@ -31,7 +31,6 @@ export default function AvatarPicker({
       <ImagePicker
         preview={null}
         error={error}
-        uploading={uploading}
         onSelect={onSelect}
         className="border-0 p-0 w-auto h-auto"
         placeholder={

--- a/components/common/ui/ImagePicker.tsx
+++ b/components/common/ui/ImagePicker.tsx
@@ -5,7 +5,6 @@ import { useId } from 'react';
 interface ImagePickerProps {
   preview: string | null;
   error?: string | null;
-  uploading?: boolean;
   onSelect: (file: File) => void;
   className?: string;
   placeholder?: React.ReactNode;
@@ -14,7 +13,6 @@ interface ImagePickerProps {
 export function ImagePicker({
   preview,
   error,
-  uploading,
   onSelect,
   className,
   placeholder,
@@ -41,11 +39,6 @@ export function ImagePicker({
           <Image src={preview} fill className="object-cover" alt="미리보기 이미지" />
         ) : (
           (placeholder ?? <span className="text-sm text-muted-foreground">이미지 선택</span>)
-        )}
-        {uploading && (
-          <div className="absolute inset-0 bg-black/40 flex items-center justify-center text-white text-sm">
-            업로드 중..
-          </div>
         )}
       </label>
       <input id={id} type="file" hidden accept="image/*" onChange={handleChange} />

--- a/components/myprofile/AuthGuard.tsx
+++ b/components/myprofile/AuthGuard.tsx
@@ -17,7 +17,7 @@ export default function AuthGuard({ children }: AuthGuardProps) {
   }, [isLoading, user, router]);
 
   if (isLoading) {
-    return <div>인증 확인 중...</div>;
+    return null;
   }
 
   if (!user) {

--- a/components/myprofile/MyProfileLayout.tsx
+++ b/components/myprofile/MyProfileLayout.tsx
@@ -5,9 +5,9 @@ interface MyProfileLayoutProps {
 
 export default function MyProfileLayout({ sidebar, content }: MyProfileLayoutProps) {
   return (
-    <main className="grid grid-cols-1 lg:grid-cols-[260px_1fr] gap-7">
+    <main className="grid grid-cols-1 min-h-screen lg:grid-cols-[260px_1fr] gap-7">
       <aside className="self-start">{sidebar}</aside>
-      <div>{content}</div>
+      <div className="h-full">{content}</div>
     </main>
   );
 }

--- a/components/myprofile/MyProfilePage.tsx
+++ b/components/myprofile/MyProfilePage.tsx
@@ -4,7 +4,7 @@ import MyReviewsPanel from './MyReviewsPanel';
 import MyWinesPanel from './MyWinesPanel';
 import MyProfileLayout from './MyProfileLayout';
 import MyProfileTabs from './MyProfileTabs';
-import { useProfileEditor } from '@/hooks/myprofile/userProfileEditor';
+import { useProfileEditor } from '@/hooks/myprofile/useProfileEditor';
 import type { ApiReview, UpdateReviewRequest } from '@/lib/api/review/review.types';
 import type { WineListItem } from '@/lib/api/wine/wine.types';
 import type { ApiUser } from '@/lib/api/user/user.types';
@@ -61,15 +61,15 @@ export default function MyProfilePage({
   }, [tab, onFetchReviews, onFetchWines]);
 
   const handleSubmit = () => {
-    onUpdateProfile(editor.derived.nextNickname, editor.derived.nextImage);
-    editor.resetUploadedImage();
+    onUpdateProfile(editor.derived.nextNickname);
   };
 
   return (
-    <>
+    <div className="min-h-screen">
       <MyProfileLayout
         sidebar={
           <ProfileSidebar
+            key={user.image + user.nickname}
             user={user}
             nickname={editor.nickname}
             onNicknameChange={editor.setNickname}
@@ -105,6 +105,6 @@ export default function MyProfilePage({
           </>
         }
       />
-    </>
+    </div>
   );
 }

--- a/components/myprofile/MyReviewsPanel.tsx
+++ b/components/myprofile/MyReviewsPanel.tsx
@@ -1,10 +1,10 @@
 import { cn } from '@/utils/cn';
 import MyReviewCard from '../reviewCard/MyReviewCard';
 import EmptyState from '../common/ui/EmptyState';
-import type { ApiReview, UpdateReviewRequest } from '@/lib/api/review/review.types';
-import { useMyReviewsPanelState } from '@/hooks/myprofile/useMyReviewsPanelState';
 import { DeleteReviewDialog } from '../review/DeleteReviewDialog';
 import ReviewFormModal from '../review/ReviewFormModal';
+import { useMyReviewsPanelState } from '@/hooks/myprofile';
+import type { ApiReview, UpdateReviewRequest } from '@/lib/api/review/review.types';
 
 interface MyReviewsPanelProps {
   reviews: ApiReview[];
@@ -32,7 +32,7 @@ export default function MyReviewsPanel({
         id="panel-reviews"
         aria-labelledby="tab-reviews"
         className={cn(
-          'relative lg:pl-5 lg:border-l border-t border-gray-300 flex flex-col',
+          'relative lg:pl-5 lg:border-l border-t border-gray-300 flex flex-col h-full',
           className
         )}
       >

--- a/components/myprofile/MyWinesPanel.tsx
+++ b/components/myprofile/MyWinesPanel.tsx
@@ -42,7 +42,7 @@ export default function MyWinesPanel({
         id="panel-reviews"
         aria-labelledby="tab-reviews"
         className={cn(
-          'relative lg:pl-5 lg:border-l border-t border-gray-300 flex flex-col',
+          'relative lg:pl-5 lg:border-l border-t border-gray-300 flex flex-col h-full',
           className
         )}
       >

--- a/components/wine/WineImageUpload.tsx
+++ b/components/wine/WineImageUpload.tsx
@@ -15,7 +15,6 @@ export default function WineImageUpload({ value, onChange, error }: WineImageUpl
   const {
     preview,
     error: imagePickerError,
-    uploading,
     handleFile,
   } = useImagePicker({
     rules: RULES,
@@ -27,7 +26,6 @@ export default function WineImageUpload({ value, onChange, error }: WineImageUpl
       <ImagePicker
         preview={preview || value || null}
         error={imagePickerError ?? error}
-        uploading={uploading}
         onSelect={handleFile}
         placeholder={<IconButton icon="camera" size={24} className="pointer-events-none" />}
       />

--- a/hooks/imagePicker/useImagePicker.ts
+++ b/hooks/imagePicker/useImagePicker.ts
@@ -1,4 +1,3 @@
-import { toast } from '@/components/common/ui/Toast';
 import { uploadImage } from '@/lib/api/infra/image';
 import { ImageValidation, ValidationRule } from '@/utils/imagePicker/ImageValidation';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -41,6 +40,8 @@ export function useImagePicker({ rules, onUploaded }: useImagePickerOptions) {
       try {
         setUploading(true);
         const res = await uploadImage(safeFile);
+        if (urlRef.current) URL.revokeObjectURL(urlRef.current);
+        setPreview(res.url);
         onUploaded(res.url);
       } catch (err) {
         console.error('이미지 업로드 실패', err);
@@ -49,7 +50,7 @@ export function useImagePicker({ rules, onUploaded }: useImagePickerOptions) {
         setUploading(false);
       }
     },
-    [rules, onUploaded]
+    [rules, onUploaded, uploading]
   );
 
   useEffect(() => {

--- a/hooks/myprofile/index.ts
+++ b/hooks/myprofile/index.ts
@@ -2,5 +2,6 @@ export * from './useMyReviews';
 export * from './useMyWineActions';
 export * from './useMyWines';
 export * from './useUpdateProfile';
-export * from './userProfileEditor';
+export * from './useProfileEditor';
 export * from './useMyWinesPanelState';
+export * from './useMyReviewsPanelState';

--- a/hooks/myprofile/useProfileEditor.ts
+++ b/hooks/myprofile/useProfileEditor.ts
@@ -2,46 +2,50 @@ import { ApiUser } from '@/lib/api/user/user.types';
 import { useEffect, useMemo, useState } from 'react';
 import { useImagePicker } from '../imagePicker/useImagePicker';
 import { isImage, maxSize } from '@/utils/imagePicker/ImageValidation';
+import { updateMe } from '@/lib/api/user/user';
+import { useAuth } from '@/providers/Auth/AuthProvider';
+import { toast } from '@/components/common/ui/Toast';
 
 type UserProfile = Pick<ApiUser, 'image' | 'nickname'>;
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
 
 export function useProfileEditor(user: UserProfile) {
+  const { updateUser } = useAuth();
   const [nickname, setNickname] = useState(() => user.nickname);
-  const [uploadedImageUrl, setUploadedImageUrl] = useState<string | null>(null);
 
   const picker = useImagePicker({
     rules: [isImage, maxSize(MAX_FILE_SIZE)],
-    onUploaded: url => setUploadedImageUrl(url),
+    onUploaded: async url => {
+      try {
+        const updated = await updateMe({
+          image: url,
+        });
+        updateUser(updated);
+      } catch {
+        toast.error('프로필 이미지 업데이트 실패');
+      }
+    },
   });
 
   const derived = useMemo(() => {
     const nextNickname = nickname.trim();
-    const nextImage = uploadedImageUrl ?? user.image;
 
     const isNicknameChange = nextNickname !== user.nickname;
-    const isImageChanged = nextImage !== user.image;
+    const isDirty = isNicknameChange;
 
-    const isDirty = isNicknameChange || isImageChanged;
     const isDisabled = !isDirty || !nextNickname || picker.uploading || !!picker.error;
 
     return {
       nextNickname,
-      nextImage,
       isDirty,
       isDisabled,
     };
-  }, [nickname, uploadedImageUrl, user.nickname, user.image, picker.uploading, picker.error]);
-
-  const resetUploadedImage = () => setUploadedImageUrl(null);
+  }, [nickname, user.nickname, picker.uploading, picker.error]);
 
   return {
     nickname,
     setNickname,
-    uploadedImageUrl,
-    setUploadedImageUrl,
-    resetUploadedImage,
     picker,
     derived,
   };

--- a/hooks/myprofile/useUpdateProfile.ts
+++ b/hooks/myprofile/useUpdateProfile.ts
@@ -33,11 +33,21 @@ export function useUpdateProfile() {
       updateUser(updatedUser);
       toast.success('프로필이 수정되었습니다.');
     } catch (err: unknown) {
-      if (err instanceof Error) {
-        toast.error(err.message);
-      } else {
-        toast.error('프로필 수정에 실패했습니다.');
+      let message = '프로필 수정에 실패했습니다.';
+
+      if (
+        typeof err === 'object' &&
+        err !== null &&
+        'data' in err &&
+        typeof err.data === 'object' &&
+        err.data !== null &&
+        'message' in err.data &&
+        typeof err.data.message === 'string'
+      ) {
+        message = err.data.message;
       }
+
+      toast.error(message);
     } finally {
       setIsUpdating(false);
     }


### PR DESCRIPTION
## 어떤 작업을 하셨나요?

작업하신 내용을 팀원들이 알아보기 쉽게 설명해주세요.
(예: 로그인 페이지 UI 퍼블리싱, 유효성 검사 로직 추가)

- myprofile 페이지 디자인 고도화
- 이미지 즉시 반영 로직 추가

## 같이 고민해 주세요 (리뷰 포인트)

단순히 코드를 보는 것을 넘어, 어떤 고민을 했는지 나눠주세요.
(예: 이 로직을 훅으로 분리하는 게 맞는지 확신이 안 섭니다. / A방식과 B방식 중 성능 때문에 A를 택했는데 의견 궁금합니다.)

- 이미지는 업로드하면 바로 서버에 반영되도록 로직 수정했습니다.
- 인증 확인 중.. 문구 삭제했습니다.
- container width가 gnb 크기보다 작아져있어 원상복구 시켰습니다.
- myprofile page divider가 콘텐츠 범위만큼만 나오던 현상도 해결했습니다.

## 관련된 이슈

이 PR이 머지되면 닫히는 이슈가 있다면 적어주세요.
Closes #218 

## 테스트 결과 (스크린샷)

작업한 화면을 캡처하거나, 동작 결과를 첨부해주시면 리뷰어가 빠르게 이해할 수 있습니다.
(스크린샷이 없으면 리뷰가 늦어질 수 있어요!)
